### PR TITLE
Fix the crowded rows in the left of the prefsdialog

### DIFF
--- a/ds9/library/menu.tcl
+++ b/ds9/library/menu.tcl
@@ -152,6 +152,13 @@ proc ThemeConfigMenu {w} {
 	[ttk::style lookup TMenubutton -background active]
 }
 
+proc FontChange {} {
+    global pds9
+    set mainFont "$pds9(font) $pds9(font,size) $pds9(font,weight) $pds9(font,slant)"
+    ttk::style configure Treeview -rowheight \
+	[expr {[font metrics $mainFont -linespace] + [font metrics $mainFont -descent]}]
+}
+
 proc ThemeChange {} {
     global ds9
     global pds9
@@ -161,6 +168,7 @@ proc ThemeChange {} {
 	win32 {ttk::style theme use $pds9(theme)}
 	aqua {}
     }
+    FontChange
 }
 
 proc ThemeForeground {} {

--- a/ds9/library/prefsdialog.tcl
+++ b/ds9/library/prefsdialog.tcl
@@ -228,9 +228,9 @@ proc PrefsDialogGeneral {} {
 
     ttk::label $f.tgui -text [msgcat::mc {GUI}]
     FontMenuButton $f.gui pds9 font font,size font,weight font,slant \
-	[list SetDefaultFont true]
+	"SetDefaultFont true; FontChange"
     ttk::button $f.bgui -text [msgcat::mc {Reset}] \
-	-command ResetDefaultFont
+	-command "ResetDefaultFont; FontChange"
 
     ttk::label $f.ttext -text [msgcat::mc {Text}]
     FontMenuButton $f.text pds9 text,font \

--- a/ds9/library/prefsdialog.tcl
+++ b/ds9/library/prefsdialog.tcl
@@ -41,7 +41,7 @@ proc PrefsDialog {{which {}}} {
     set dprefs(listbox) [ttk::treeview $f.box \
 			  -yscroll [list $f.scroll set] \
 			  -selectmode browse \
-			  -height 28 \
+			  -height 29 \
 			  -show tree \
 			 ]
 


### PR DESCRIPTION
Set the rowheight to the current font size. Prevent scrolling by setting the correct number of rows to be shown.

This fixes #132 