### PR TITLE
fix missing space in block examples

### DIFF
--- a/ds9/doc/ref/command.html
+++ b/ds9/doc/ref/command.html
@@ -343,17 +343,17 @@ $ds9 -blink interval 1</tt><br>
 &nbsp;&nbsp;&nbsp; [open|close]<br>
 &nbsp;<br>
 Example:<br>
-$ds9-block4<br>
-$ds9-block4 2<br>
-$ds9-blockto 4<br>
-$ds9-blockto 4 2<br>
-$ds9-blockin<br>
-$ds9-blockout<br>
-$ds9-blockto fit<br>
-$ds9-blockmatch<br>
-$ds9-blocklock yes<br>
-$ds9-blockopen<br>
-$ds9-blockclose<br></tt>
+$ds9 -block 4<br>
+$ds9 -block 4 2<br>
+$ds9 -block to 4<br>
+$ds9 -block to 4 2<br>
+$ds9 -block in<br>
+$ds9 -block out<br>
+$ds9 -block to fit<br>
+$ds9 -block match<br>
+$ds9 -block lock yes<br>
+$ds9 -block open<br>
+$ds9 -block close<br></tt>
 <p><b><a name="blue" id="blue"></a>blue</b></p>
 <p>For RGB frames, sets the current color channel to blue.</p>
 <tt>Syntax:<br>


### PR DESCRIPTION
The `block` command line examples are missing spaces.