### PR TITLE
fix typo piles => pipes

### DIFF
--- a/funtools/util/xlaunch.c
+++ b/funtools/util/xlaunch.c
@@ -564,7 +564,7 @@ pid_t LaunchPid()
 #ifdef ANSI_FUNC
 int Launch(char *cmdstring, int attach, char **stdfiles, int *pipes)
 #else
-int Launch(cmdstring, attach, stdfiles, piles)
+int Launch(cmdstring, attach, stdfiles, pipes)
      char *cmdstring;
      int attach;
      char **stdfiles;


### PR DESCRIPTION
The false branch of the  #ifdef ANSI_FUNC conditional mis-spells the function argument 'pipes' as 'piles'.  This branch doesn't seem to be taken, so technically this shouldn't change behavior. but fixing this lessens the differences with Eric Mandel's funtools distribution.
