### PR TITLE
use locally built tclsh instead of system version

### DIFF
--- a/ds9/make.include
+++ b/ds9/make.include
@@ -7,14 +7,14 @@ vpath %.fcl $(prefix)/ds9/parsers
 # -w generate warnings
 # -d generate lexer table
 $(prefix)/ds9/parsers/%parser.tcl : %parser.tac
-	tclsh $(prefix)/taccle/taccle.tcl -p $* -d $<
-#	tclsh $(prefix)/taccle/taccle.tcl -p $* -d -w -v $<
+	$(TCLSH_PROG) $(prefix)/taccle/taccle.tcl -p $* -d $<
+#	$(TCLSH_PROG) $(prefix)/taccle/taccle.tcl -p $* -d -w -v $<
 	echo "package provide DS9 1.0" | cat - $@ > tmp && mv tmp $@
 
 # -d debug
 $(prefix)/ds9/parsers/%lex.tcl : %lex.fcl
-	tclsh $(prefix)/fickle/fickle.tcl -P $* $<
-#	tclsh $(prefix)/fickle/fickle.tcl -P $* -d $<
+	$(TCLSH_PROG) $(prefix)/fickle/fickle.tcl -P $* $<
+#	$(TCLSH_PROG) $(prefix)/fickle/fickle.tcl -P $* -d $<
 	echo "package provide DS9 1.0" | cat - $@ > tmp && mv tmp $@
 
 #--------------------------library
@@ -27,7 +27,7 @@ $(LIBDIR)/library : $(SRCP:.tac=.tcl) $(SRCP:.tac=.tab.tcl) $(SRCL:.fcl=.tcl) $(
 	cp -prf $? "$@"
 # must do it this way for win
 	cd "$@"; \
-	echo "pkg_mkIndex . *.tcl; exit" | tclsh
+	echo "pkg_mkIndex . *.tcl; exit" | $(TCLSH_PROG)
 	touch "$@"
 
 #--------------------------support
@@ -54,7 +54,7 @@ $(LIBDIR)/tls	: $(prefix)/tls/tls.tcl
 	cp -prf $? "$@"
 # must do it this way for win
 	cd "$@"; \
-	echo "pkg_mkIndex . *.tcl; exit" | tclsh
+	echo "pkg_mkIndex . *.tcl; exit" | $(TCLSH_PROG)
 
 #--------------------------tkblt
 
@@ -63,7 +63,7 @@ $(LIBDIR)/tkblt	: $(prefix)/tkblt/library/*.tcl
 	cp -p $? "$@"
 # must do it this way for win
 	cd "$@"; \
-	echo "pkg_mkIndex . *.tcl; exit" | tclsh
+	echo "pkg_mkIndex . *.tcl; exit" | $(TCLSH_PROG)
 
 #--------------------------tkcon
 
@@ -71,7 +71,7 @@ $(LIBDIR)/tkcon	: $(prefix)/tkcon
 	cp -prf $? "$@"
 # must do it this way for win
 	cd "$@"; \
-	echo "pkg_mkIndex . *.tcl; exit" | tclsh
+	echo "pkg_mkIndex . *.tcl; exit" | $(TCLSH_PROG)
 
 #--------------------------tcllib
 


### PR DESCRIPTION
This change ensures that ds9 is using the version of `tclsh` that it builds. 

on some newer systems that have switched to Tcl9 (eg Fedora 44) which causes conflicts when things are built. 