### PR TITLE
Cpt city url

### DIFF
--- a/ds9/library/colorbar.tcl
+++ b/ds9/library/colorbar.tcl
@@ -388,7 +388,7 @@ proc CreateColorbarBase {frame} {
     # now init new colorbar to prev values
     # must come after all cmaps have been defined
     $which colorbar $sav
-    
+
     # enable events
     BindEventsColorbar $which
 
@@ -408,7 +408,7 @@ proc CreateColorbarRGB {frame} {
 	hsv -
 	hls {set sav [colorbarrgb get colorbar]}
     }
-    
+
     set which ${frame}cb
 
     $ds9(canvas) create colorbarrgb$ds9(visual)$ds9(depth) \
@@ -455,7 +455,7 @@ proc CreateColorbarHSV {frame} {
 	rgb -
 	hls {set sav [colorbarhsv get colorbar]}
     }
-    
+
     set which ${frame}cb
 
     $ds9(canvas) create colorbarhsv$ds9(visual)$ds9(depth) \
@@ -502,7 +502,7 @@ proc CreateColorbarHLS {frame} {
 	rgb -
 	hsv {set sav [colorbarhls get colorbar]}
     }
-    
+
     set which ${frame}cb
 
     $ds9(canvas) create colorbarhls$ds9(visual)$ds9(depth) \
@@ -608,7 +608,7 @@ proc BindEventsColorbar {which} {
 
 proc UnBindEventsColorbar {which} {
     global ds9
-    
+
     global debug
     if {$debug(tcl,events)} {
 	puts stderr "UnBindEventsColorbar $which"
@@ -655,7 +655,7 @@ proc ResetColormap {} {
 
 proc LoadColormap {} {
     global icolorbar
-    
+
     LoadColormapFile [OpenFileDialog colorbarfbox $icolorbar(top)]
 }
 
@@ -730,7 +730,7 @@ proc SaveColormap {} {
 
 proc SaveColormapFile {fn} {
     global current
-    
+
     if {$fn == {}} {
 	return
     }
@@ -767,7 +767,7 @@ proc SaveContrastBias {} {
     if {$fn == {}} {
 	return
     }
-    
+
     if {![catch {set ch [open $fn w]}]} {
 	puts $ch "$dcolorbar(contrast) $dcolorbar(bias)"
 	close $ch
@@ -785,7 +785,7 @@ proc ColorbarEnter {frame x y} {
     set cb ${frame}cb
 
     # check to see if this event was generated while processing other events
-    if {$ds9(b1) || $ds9(sb1) || $ds9(cb1) || 
+    if {$ds9(b1) || $ds9(sb1) || $ds9(cb1) ||
 	$ds9(csb1) || $ds9(b2) || $ds9(b3)} {
 	return
     }
@@ -969,7 +969,7 @@ proc ColorbarMotion1 {frame x y} {
     set cb ${frame}cb
 
     # abort if we are here by accident (such as a double click)
-    if {($ds9(b1) == 0) && ($ds9(sb1) == 0) && 
+    if {($ds9(b1) == 0) && ($ds9(sb1) == 0) &&
 	($ds9(cb1) == 0) && ($ds9(csb1) == 0)} {
 	return
     }
@@ -1002,7 +1002,7 @@ proc ColorbarRelease1 {frame x y} {
     set cb ${frame}cb
 
     # abort if we are here by accident (such as a double click)
-    if {($ds9(b1) == 0) && ($ds9(sb1) == 0) && 
+    if {($ds9(b1) == 0) && ($ds9(sb1) == 0) &&
 	($ds9(cb1) == 0) && ($ds9(csb1) == 0)} {
 	return
     }
@@ -1108,7 +1108,7 @@ proc ColorbarRelease3 {frame x y} {
     }
 
     $frame colormap end
-    
+
     LockColor $frame
     UpdateColorDialog
 }
@@ -1155,7 +1155,7 @@ proc MatchColor {which} {
 
 proc LockColorCurrent {} {
     global current
-    
+
     if {$current(frame) != {}} {
 	LockColor $current(frame)
     }
@@ -1229,7 +1229,7 @@ proc UpdateColormapLevelMosaic {which x y sys} {
 	return
     }
 
-    if {($current(frame) == $which) && 
+    if {($current(frame) == $which) &&
 	($scale(scope) == "local") &&
 	[$which has fits mosaic]} {
 
@@ -1260,7 +1260,7 @@ proc TicksDialog {} {
 
 proc OpenColorTag {} {
     global icolorbar
-    
+
     LoadColorTag [OpenFileDialog colortagfbox $icolorbar(top)]
 }
 
@@ -1340,7 +1340,7 @@ proc ColorTagDialog {frame x y} {
     # Buttons
     set f [ttk::frame $w.buttons]
     ttk::button $f.ok -text [msgcat::mc {OK}] -command {set ed2(ok) 1} \
-	-default active 
+	-default active
     ttk::button $f.cancel -text [msgcat::mc {Cancel}] -command {set ed2(ok) 0}
     pack $f.ok $f.cancel -side left -expand true -padx 2 -pady 4
 
@@ -1400,9 +1400,8 @@ proc ColormapDialog {} {
     $mb.file add command -label [msgcat::mc {Apply}] \
 	-command ApplyColormap
     $mb.file add separator
-# url is correct, no https available
     $mb.file add command -label [msgcat::mc {Download Colormap}] \
-	-command {HV cpt CPT-CITY http://seaviewsensing.com/pub/cpt-city}
+	-command {HV cpt CPT-CITY https://phillips.shef.ac.uk/pub/cpt-city/}
     $mb.file add separator
     $mb.file add command -label [msgcat::mc {Load Contrast/Bias}]\
 	-command LoadContrastBias
@@ -1478,7 +1477,7 @@ proc ColormapDialog {} {
 
     # Param
     set f [ttk::frame $w.param]
- 
+
     slider $f.cslider 0. 10. [msgcat::mc {Contrast}] \
 	dcolorbar(contrast) [list AdjustColormap]
     slider $f.bslider 0. 1. [msgcat::mc {Bias}] \
@@ -1499,7 +1498,7 @@ proc ColormapDialog {} {
 	-command ApplyColormap
     ttk::button $f.close -text [msgcat::mc {Close}] \
 	-command ColormapDestroyDialog
-    pack $f.apply $f.close -side left -expand true -padx 2 -pady 4 
+    pack $f.apply $f.close -side left -expand true -padx 2 -pady 4
 
     # Fini
     ttk::separator $w.sep -orient horizontal
@@ -1666,7 +1665,7 @@ proc UpdateColorDialogCmaps {state} {
 proc LayoutColorbarAdjust {} {
     global ds9
     global colorbar
-    
+
     if {$colorbar(numerics)} {
 	set font [$ds9(canvas) itemcget colorbar -font]
 	set fontsize [$ds9(canvas) itemcget colorbar -fontsize]
@@ -1802,7 +1801,7 @@ proc ColorbarUpdateView {} {
     # update all colorbars
     foreach ff $ds9(frames) {
 	set cb ${ff}cb
-	
+
 	$cb configure \
 	    -size $colorbar(size) \
 	    -ticks $colorbar(ticks) \
@@ -1904,7 +1903,7 @@ proc CmapCmd {item} {
 }
 
 proc CmapValueCmd {c b} {
-    global current 
+    global current
 
     if {$current(frame) != {}} {
 	EvalLockColorbarCurrent [list $current(colorbar) adjust $c $b]

--- a/ds9/library/hvsup.tcl
+++ b/ds9/library/hvsup.tcl
@@ -184,7 +184,7 @@ proc HVProcessURLFile {varname url query rr} {
     global $varname
 
     upvar $rr r
-    
+
     global ds9
 
     global debug
@@ -214,7 +214,7 @@ proc HVProcessURLFTP {varname url query rr} {
     global $varname
 
     upvar $rr r
-    
+
     global ds9
 
     global debug
@@ -276,7 +276,7 @@ proc HVProcessURLHTTP {varname url query rr sync} {
     global $varname
 
     upvar $rr r
-    
+
     global ds9
 
     global debug
@@ -536,7 +536,12 @@ proc HVParseMeta {varname} {
 		    default {}
 		}
 	    }
-
+            content-disposition {
+                # The regex looks for filename=" and captures everything until the closing "
+                if {[regexp {filename="([^\"]+)"} $value -> filename]} {
+                  set var(filename) $filename
+                }
+            }
 	    refresh {
 		set f [split $value \;]
 		set var(refresh,time) [lindex $f 0]
@@ -575,7 +580,7 @@ proc HVParseMeta {varname} {
 			    no-transform {}
 			    only-if-cached {}
 			    cache-extension {}
-			    
+
 			    must-revalidate {}
 			    proxy-revalidate {}
 			}
@@ -663,7 +668,15 @@ proc HVLoadFile {varname path} {
 	}
     }
 
-    switch -- [string tolower [file extension $path]] {
+    set fn [file extension $path]
+    if { [info exists var(filename)] } {
+        if {$var(filename) ne ""} {
+          set fn [file extension $var(filename)]
+        }
+    }
+    set extn [string tolower $fn]
+
+    switch -- $extn {
 	.html -
 	.htm {set var(mime) "text/html"}
 	.gif {set var(mime) "image/gif"}
@@ -892,11 +905,11 @@ proc HVParseSingle {varname} {
 	"text/html" -
 	"text/plain" -
 	"application/octet-stream" {
-	    # it never fails, someone can't get there mime types correct. 
+	    # it never fails, someone can't get there mime types correct.
 	    # Override the mime type based on path
 
 	    ParseURL $var(url) r
-	    set path [file tail $r(path)]  
+	    set path [file tail $r(path)]
 
 	    # set content-encoding
 	    switch -- [file extension $path] {
@@ -918,8 +931,16 @@ proc HVParseSingle {varname} {
 		}
 	    }
 
+            set fn [file extension $path]
+            if {[info exists var(filename)]} {
+                if {$var(filename) ne ""} {
+                    set fn [file extension $var(filename)]
+                }
+            }
+            set extn [string tolower $fn]
+
 	    # set Content-Type
-	    switch -- [file extension $path] {
+            switch -- $extn {
 		.html -
 		.htm {set var(mime) "text/html"}
 		.gif {set var(mime) "image/gif"}
@@ -1250,8 +1271,14 @@ proc HVParseColormap {varname} {
 
     set fn [HVParseMimeParam $varname "name"]
     if {$fn == {}} {
-	ParseURL $var(url) r
-	set fn [file tail $r(path)]
+        ParseURL $var(url) r
+        set fn [file tail $r(path)]
+    }
+
+    if { [info exists var(filename)] } {
+        if {$var(filename) ne ""} {
+          set fn $var(filename)
+        }
     }
 
     if {![catch {file rename -force $var(fn) $ds9(tmpdir)/$fn}]} {
@@ -1434,7 +1461,7 @@ proc HVUpdateDialog {varname} {
     set id $var(index)
     set id [incr id -1]
     if {[info exists ${varname}(index,$id)]} {
-	$var(mb).view entryconfig [msgcat::mc {Back}] -state normal    
+	$var(mb).view entryconfig [msgcat::mc {Back}] -state normal
     } else {
 	$var(mb).view entryconfig [msgcat::mc {Back}] -state disabled
     }
@@ -1442,7 +1469,7 @@ proc HVUpdateDialog {varname} {
     set id $var(index)
     set id [incr id 1]
     if {[info exists ${varname}(index,$id)]} {
-	$var(mb).view entryconfig [msgcat::mc {Forward}] -state normal    
+	$var(mb).view entryconfig [msgcat::mc {Forward}] -state normal
     } else {
 	$var(mb).view entryconfig [msgcat::mc {Forward}] -state disabled
     }
@@ -1617,6 +1644,7 @@ proc HVSetResult {varname code mime} {
     set var(cache,images) 1
     set var(expire) 0
     set var(encoding) {}
+    set var(filename) {}
     set var(transfer) {}
     set var(refresh,time) 0
     set var(refresh,url) {}
@@ -1830,7 +1858,7 @@ proc HVImageURL {varname url width height} {
 		    200 -
 		    203 -
 		    503 {set ii 0}
-		
+
 		    201 -
 		    300 -
 		    301 -
@@ -1976,7 +2004,7 @@ proc HVFontCB {varname sz args} {
 	    italic {set slant italic}
 	}
     }
-    
+
     switch -- $sz {
 	0 {incr size -3}
 	1 {incr size -2}


### PR DESCRIPTION
This updates the colormap download link to the cpt-city web site.

However, the new site uses a restful API where clicking on a `.sao` download link -- the link does not have the file name; it's a hash.  The HTML headers have a `Content-Disposition` value that provides the actual file name. Need to update the HTML library/callback to look for `Content-Disposition` and  use the `filename` it provides to switch to guesstimate the correct MIME type. 