### PR TITLE
Samp xpa fixes

### DIFF
--- a/ds9/library/util.tcl
+++ b/ds9/library/util.tcl
@@ -124,7 +124,7 @@ proc EvalLock {var which cmd} {
 
 proc EvalLockColorbarCurrent {cmd} {
     global current
-    
+
     EvalLockColorbar $current(frame) $cmd
 }
 
@@ -203,7 +203,7 @@ proc UpdateDS9 {} {
     UpdateColorMenu
     UpdateRegionMenu
     # wcs(system) set here
-    UpdateWCSMenu 
+    UpdateWCSMenu
     UpdateIllustrateMenu
     UpdateAnalysisMenu
     UpdateAnalysisButtonbar
@@ -238,7 +238,7 @@ proc UpdateDS9 {} {
 
     RefreshInfoBox $current(frame)
     UpdateColormapLevel
-    
+
     if {$debug(tcl,update)} {
 	puts stderr "UpdateDS9 end\n"
     }
@@ -583,7 +583,7 @@ proc ProcessSend {proc id sock fn ext rr} {
 
 proc SourceInitFileDir {ext} {
     global ds9
-    
+
     foreach pp {{.} {}} {
 	set fn $pp$ds9(app)$ext
 	set ff [file join [GetEnvHome] $fn]
@@ -609,7 +609,7 @@ proc SourceInitFile {fn} {
 		if {![ValidReadOnly [lindex $pp 3]] ||
 		    ![ValidReadOnly [lindex $pp 4]]} {
 		    set msg "[msgcat::mc {Invalid file permissions detected}]: $fn [msgcat::mc {Please change the file's permission to disable other users write access. Use anyway?}]"
-		    
+
 		    if {[tk_messageBox -type yesno -icon question -message $msg] != {yes}} {
 			# failed to execute
 			return 0
@@ -665,7 +665,7 @@ proc LanguageToName {which} {
 proc SetLanguage {ll} {
     global ds9
     global pds9
-    
+
     set pds9(language,name) [LanguageToName $ll]
 
     set x 0
@@ -695,12 +695,12 @@ proc SetLanguage {ll} {
     }
 }
 
-proc InitTempDir {} { 
+proc InitTempDir {} {
     global ds9
     global env
 
     # check environment vars first
-    #   windows is very picky as to file name format 
+    #   windows is very picky as to file name format
     if {[info exists env(TEMP)]} {
 	set ds9(tmpdir) [file normalize [file nativename $env(TEMP)]]
     } elseif {[info exists env(TMP)]} {
@@ -945,16 +945,16 @@ proc AboutBoxDefault {} {
     set f [ttk::frame $w.param]
     canvas $f.c -background white -height 300 -width 550
     pack $f.c -fill both -expand true
-    
+
     set ed(sun) [image create photo -file $ds9(root)/doc/sun.png]
-    
+
     $f.c create image 0 0 -image $ed(sun) -anchor nw
     $f.c create text 120 12 -text $help(about) -anchor nw -width 450
 
     # Buttons
     set f [ttk::frame $w.buttons]
     ttk::button $f.ok -text [msgcat::mc {OK}] -command {set ed(ok) 1} \
-	-default active 
+	-default active
     pack $f.ok -padx 2 -pady 2
 
     bind $w <Return> {set ed(ok) 1}
@@ -993,7 +993,7 @@ proc QuitDS9 {} {
     if {[info exists samphub]} {
 	catch {SAMPHubStop}
     }
-    
+
     # close IIS ports
     catch {IISClose}
 
@@ -1032,13 +1032,13 @@ proc OpenSource {} {
 
 proc OpenConsole {} {
     global ds9
-    
+
     if {[winfo exists ".tkcon"]} {
 	tkcon show
     } else {
 	set ::tkcon::OPT(exec) {}
 	set ::tkcon::OPT(font) [font actual TkFixedFont]
-	
+
 	tkcon::Init
 
 	switch $ds9(wm) {
@@ -1373,7 +1373,7 @@ proc ProxyHTTP {} {
     set auth {}
     if {$phttp(proxy) && $phttp(auth)} {
 	set auth [list "Proxy-Authorization" [concat "Basic" [base64::encode $phttp(auth,user):$phttp(auth,passwd)]]]
-    } 
+    }
 
     return $auth
 }
@@ -1429,7 +1429,7 @@ proc FixSpec {sysname skyname formatname defsys defsky defformat} {
 	    set sky $sys
 	    set sys wcs
 	}
-	
+
 	default {
 	    set format $sky
 	    set sky $sys
@@ -1469,7 +1469,7 @@ proc FixSpec {sysname skyname formatname defsys defsky defformat} {
 proc MacOSPhotoFix {top xx yy} {
     global ds9
     global tcl_platform
-    
+
     switch $ds9(wm) {
 	x11 {
 	    if {$tcl_platform(os) == {Darwin}} {
@@ -1482,7 +1482,7 @@ proc MacOSPhotoFix {top xx yy} {
 	aqua {macos sc yes}
 	win32 {}
     }
-    
+
     return {}
 }
 
@@ -1691,7 +1691,7 @@ proc DataSendCmd {sys sky xx yy ww hh strip} {
     global current
 
     if {$current(frame) == {}} {
-	return
+        error "No current frame."
     }
 
     $current(frame) get data $sys $sky $xx $yy $ww $hh rr

--- a/ds9/parsers/viewsendparser.tac
+++ b/ds9/parsers/viewsendparser.tac
@@ -63,7 +63,7 @@ viewsend: LAYOUT_ {ProcessSendCmdGet view layout}
 # backward compatibility
  | HORZGRAPH_ {ProcessSendCmdYesNo view graph,horz}
 # backward compatibility
- | VERTGRAPH_ {ProcessSendCmdYesNo view graph,graph}
+ | VERTGRAPH_ {ProcessSendCmdYesNo view graph,vert}
 
  | FILENAME_ {ProcessSendCmdYesNo view info,filename}
  | OBJECT_ {ProcessSendCmdYesNo view info,object}
@@ -81,7 +81,7 @@ viewsend: LAYOUT_ {ProcessSendCmdGet view layout}
  | hsv
 
  | RGB_ rgb
- | HLS_ hls 
+ | HLS_ hls
  | HSV_ hsv
  ;
 
@@ -94,14 +94,13 @@ hls : HUE_ {ProcessSendCmdYesNo hls hue}
  | LIGHTNESS_ {ProcessSendCmdYesNo hls lightness}
  | SATURATION_ {ProcessSendCmdYesNo hls saturation}
  ;
- 
+
 hsv : HUE_ {ProcessSendCmdYesNo hsv hue}
  | SATURATION_ {ProcessSendCmdYesNo hsv saturation}
  | VALUE_ {ProcessSendCmdYesNo hsv value}
  ;
- 
-graph :
- | HORIZONTAL_ {ProcessSendCmdYesNo view graph,horz}
+
+graph : HORIZONTAL_ {ProcessSendCmdYesNo view graph,horz}
  | VERTICAL_ {ProcessSendCmdYesNo view graph,vert}
  ;
 

--- a/ds9/parsers/viewsendparser.tcl
+++ b/ds9/parsers/viewsendparser.tcl
@@ -110,7 +110,6 @@ array set viewsend::table {
   61:0,target 51
   0:268,target 12
   45:0,target 37
-  37:0,target 68
   14:0 reduce
   29:0,target 29
   30:0,target 30
@@ -270,7 +269,7 @@ array set viewsend::table {
   74:0,target 58
   53:317,target 71
   0:272,target 16
-  66:0,target 69
+  66:0,target 68
   7:0 reduce
   58:0,target 65
   52:313,target 55
@@ -327,7 +326,6 @@ array set viewsend::table {
   0:284,target 28
   0:263,target 7
   16:0 reduce
-  37:0 reduce
   0:313,target 55
   58:0 reduce
   0:282,target 26
@@ -337,7 +335,7 @@ array set viewsend::table {
   13:0 reduce
   2:0,target 2
   34:0 reduce
-  67:0,target 70
+  67:0,target 69
   0:311,target 53
   60:0,target 67
   59:0,target 66
@@ -421,7 +419,6 @@ array set viewsend::rules {
   5,l 321
   27,l 321
   48,l 322
-  70,l 326
   69,l 326
   2,l 320
   24,l 321
@@ -446,7 +443,6 @@ array set viewsend::rules {
   3,dc 1
   41,dc 1
   55,dc 1
-  70,dc 1
   69,dc 1
   18,dc 1
   33,dc 1
@@ -459,7 +455,7 @@ array set viewsend::rules {
   40,dc 1
   39,dc 1
   54,dc 1
-  68,dc 0
+  68,dc 1
   17,dc 1
   32,dc 1
   8,dc 1
@@ -526,7 +522,6 @@ array set viewsend::rules {
   21,line 135
   17,line 131
   14,line 128
-  70,line 202
   69,line 201
   11,line 125
   66,line 196
@@ -592,7 +587,7 @@ array set viewsend::lr1_table {
   14,trans {}
   36 {{53 0 1}}
   33,trans {}
-  37 {{42 0 1} {68 0 0} {69 0 0} {70 0 0}}
+  37 {{42 0 1} {68 0 0} {69 0 0}}
   52,trans {{313 55} {314 56} {315 57} {323 69}}
   38 {{43 0 1}}
   71,trans {}
@@ -650,11 +645,11 @@ array set viewsend::lr1_table {
   59,trans {}
   64 {{54 0 1}}
   65 {{55 0 1}}
-  66 {{69 0 1}}
+  66 {{68 0 1}}
   26,trans {}
   8,trans {}
   45,trans {}
-  67 {{70 0 1}}
+  67 {{69 0 1}}
   64,trans {}
   68 {{42 0 2}}
   70 {{62 0 1}}
@@ -815,7 +810,7 @@ array set viewsend::token_id_table {
   307,t 0
   297,t 0
   262,line 13
-  327,line 203
+  327,line 202
   0,t 0
   0 {$}
   262,title WCSA
@@ -1168,7 +1163,7 @@ proc viewsend::yyparse {} {
                     40 { ProcessSendCmdYesNo view colorbar }
                     41 { ProcessSendCmdYesNo colorbar numerics }
                     43 { ProcessSendCmdYesNo view graph,horz }
-                    44 { ProcessSendCmdYesNo view graph,graph }
+                    44 { ProcessSendCmdYesNo view graph,vert }
                     45 { ProcessSendCmdYesNo view info,filename }
                     46 { ProcessSendCmdYesNo view info,object }
                     47 { ProcessSendCmdYesNo view info,keyword }
@@ -1187,8 +1182,8 @@ proc viewsend::yyparse {} {
                     65 { ProcessSendCmdYesNo hsv hue }
                     66 { ProcessSendCmdYesNo hsv saturation }
                     67 { ProcessSendCmdYesNo hsv value }
-                    69 { ProcessSendCmdYesNo view graph,horz }
-                    70 { ProcessSendCmdYesNo view graph,vert }
+                    68 { ProcessSendCmdYesNo view graph,horz }
+                    69 { ProcessSendCmdYesNo view graph,vert }
                 }
                 unsetupvalues $dc
                 # pop off tokens from the stack if normal rule

--- a/tksao/frame/basecommand.C
+++ b/tksao/frame/basecommand.C
@@ -21,7 +21,7 @@ void Base::axesOrderCmd(int order)
   // if same do nothing
   if (order == currentContext->axesOrder())
     return;
-  
+
   currentContext->setAxesOrder(order);
   if (currentContext->fits) {
     if (!preserveMarkers) {
@@ -83,7 +83,7 @@ void Base::binCmd(const Vector& b, const Vector& vv,
   }
 }
 
-void Base::binCmd(const Vector& b, const char* x, const char* y, 
+void Base::binCmd(const Vector& b, const char* x, const char* y,
 		       const char* filter)
 {
   currentContext->setBinToFactor(b);
@@ -100,7 +100,7 @@ void Base::binCmd(const Vector& b, const char* x, const char* y,
   }
 }
 
-void Base::binCmd(const Vector& b, int d, const Vector& lim, 
+void Base::binCmd(const Vector& b, int d, const Vector& lim,
 		       const Vector& vv,
 		       const char* x, const char* y, const char* z,
 		       const char* filter)
@@ -415,7 +415,7 @@ void Base::cropCmd()
 }
 
 // used for Backup
-void Base::cropCmd(const Vector& aa, const Vector& bb, 
+void Base::cropCmd(const Vector& aa, const Vector& bb,
 		   Coord::CoordSystem sys, Coord::SkyFrame sky)
 {
   // params in DATA coords 0-n
@@ -443,9 +443,9 @@ void Base::cropCmd(const Vector& aa, const Vector& bb,
   updateMarkerCBs(&footprintMarkers);
 }
 
-void Base::cropCenterCmd(const Vector& vv, 
-			 Coord::CoordSystem sys, Coord::SkyFrame sky, 
-			 const Vector& wh, 
+void Base::cropCenterCmd(const Vector& vv,
+			 Coord::CoordSystem sys, Coord::SkyFrame sky,
+			 const Vector& wh,
 			 Coord::CoordSystem dsys, Coord::DistFormat dist)
 {
   // params in DATA coords 0-n
@@ -582,7 +582,7 @@ void Base::crop3dCmd(double z0, double z1, Coord::CoordSystem sys,
 
   // extend to edge from center
   currentContext->setCrop3dParams(min[2]-.5,max[2]+.5);
-  
+
   // set current slice if needed
   // setSlice() IMAGE (ranges 1-n)
   // context->slice() IMAGE (ranges 1-n)
@@ -593,7 +593,7 @@ void Base::crop3dCmd(double z0, double z1, Coord::CoordSystem sys,
     setSlice(2,max[2]+.5);
 
   currentContext->setSecMode(FrScale::CROPSEC);
-  
+
   currentContext->updateClip();
   updateColorScale();
   update(MATRIX);
@@ -653,8 +653,8 @@ void Base::colorScaleLogCmd(double exp)
 }
 
 void Base::contourCreateCmd(const char* color, int width, int dash,
-			    FVContour::Method method, int numlevel, 
-			    int smooth, 
+			    FVContour::Method method, int numlevel,
+			    int smooth,
 			    FrScale::ColorScaleType colorScaleType,
 			    float expo,
 			    FrScale::ClipMode clipMode, float autocut,
@@ -664,12 +664,12 @@ void Base::contourCreateCmd(const char* color, int width, int dash,
   if (DebugPerf)
     cerr << "Base::contourCreate()" << endl;
 
-  currentContext->contourCreateFV(color, width, dash, 
+  currentContext->contourCreateFV(color, width, dash,
 				  method, numlevel,
-				  smooth, 
-				  colorScaleType, 
+				  smooth,
+				  colorScaleType,
 				  expo,
-				  clipMode, autocut, 
+				  clipMode, autocut,
 				  clipScope,
 				  low, high, level);
   update(PIXMAP);
@@ -695,7 +695,7 @@ void Base::contourLoadCmd(const char* fn)
   update(PIXMAP);
 }
 
-void Base::contourLoadCmd(const char* fn, const char* color, 
+void Base::contourLoadCmd(const char* fn, const char* color,
 			  int width, int dash)
 {
   ifstream str(fn);
@@ -704,8 +704,8 @@ void Base::contourLoadCmd(const char* fn, const char* color,
   update(PIXMAP);
 }
 
-void Base::contourLoadCmd(const char* fn, 
-			  Coord::CoordSystem sys, Coord::SkyFrame sky, 
+void Base::contourLoadCmd(const char* fn,
+			  Coord::CoordSystem sys, Coord::SkyFrame sky,
 			  const char* color, int width, int dash)
 {
   ifstream str(fn);
@@ -741,7 +741,7 @@ void Base::contourPasteCmd(const char* var)
   update(PIXMAP);
 }
 
-void Base::contourPasteCmd(const char* var, const char* color, 
+void Base::contourPasteCmd(const char* var, const char* color,
 			   int width, int dash)
 {
   const char* ccmd = Tcl_GetVar(interp, var, TCL_LEAVE_ERR_MSG);
@@ -777,7 +777,7 @@ void Base::contourSaveCmd(const char* fn, Coord::CoordSystem sys,
     currentContext->contourListFV(str, sys, sky);
 }
 
-void Base::contourSaveAuxCmd(const char* fn, Coord::CoordSystem sys, 
+void Base::contourSaveAuxCmd(const char* fn, Coord::CoordSystem sys,
 			     Coord::SkyFrame sky)
 {
   ofstream str(fn);
@@ -838,11 +838,11 @@ void Base::getBinColsCmd()
 {
   if (currentContext->fits && currentContext->fits->isHist()) {
     if (currentContext->binDepth()>1)
-      Tcl_AppendResult(interp, currentContext->fits->getHistX(), " ", 
+      Tcl_AppendResult(interp, currentContext->fits->getHistX(), " ",
 		       currentContext->fits->getHistY(), " ",
 		       currentContext->fits->getHistZ(), NULL);
     else
-      Tcl_AppendResult(interp, currentContext->fits->getHistX(), " ", 
+      Tcl_AppendResult(interp, currentContext->fits->getHistX(), " ",
 		       currentContext->fits->getHistY(), NULL);
   }
   else
@@ -1070,15 +1070,15 @@ void Base::getColorMapLevelCmd(int count)
     getColorMapLevelCmd(count, currentContext->cfits->low(),
 			currentContext->cfits->high(),
 			currentContext->colorScaleType(),
-			currentContext->expo());		
+			currentContext->expo());
   else
-    getColorMapLevelCmd(count, currentContext->low(), 
+    getColorMapLevelCmd(count, currentContext->low(),
 			currentContext->high(),
 			currentContext->colorScaleType(),
-			currentContext->expo());		
+			currentContext->expo());
 }
 
-void Base::getColorMapLevelCmd(int count, const Vector& vv, 
+void Base::getColorMapLevelCmd(int count, const Vector& vv,
 			       Coord::InternalSystem ref)
 {
   if (currentContext->cfits) {
@@ -1090,7 +1090,7 @@ void Base::getColorMapLevelCmd(int count, const Vector& vv,
     }
   }
 
-  getColorMapLevelCmd(count, currentContext->low(), 
+  getColorMapLevelCmd(count, currentContext->low(),
 		      currentContext->high(),
 		      currentContext->colorScaleType(),
 		      currentContext->expo());
@@ -1133,7 +1133,7 @@ void Base::getColorMapLevelCmd(int count, double ll, double hh,
     inverseScale = new SinhInverseScale(count, ll, hh);
     break;
   case FrScale::HISTEQUSCALE:
-    inverseScale = new HistEquInverseScale(count, ll, hh, 
+    inverseScale = new HistEquInverseScale(count, ll, hh,
 				    currentContext->histequ(),
 				    HISTEQUSIZE);
     break;
@@ -1186,7 +1186,7 @@ void Base::getColorScaleCmd()
 }
 
 void Base::getColorScaleLevelCmd(int count, double ll, double hh,
-				 FrScale::ColorScaleType scaleType, 
+				 FrScale::ColorScaleType scaleType,
 				 float expo)
 {
   InverseScale* scale;
@@ -1213,7 +1213,7 @@ void Base::getColorScaleLevelCmd(int count, double ll, double hh,
     scale = new SinhInverseScale(count, ll, hh);
     break;
   case FrScale::HISTEQUSCALE:
-    scale = new HistEquInverseScale(count, ll, hh, 
+    scale = new HistEquInverseScale(count, ll, hh,
 				    currentContext->histequ(),
 				    HISTEQUSIZE);
     break;
@@ -1225,7 +1225,7 @@ void Base::getColorScaleLevelCmd(int count, double ll, double hh,
   ostringstream str;
   str << *scale << ends;
   Tcl_AppendResult(interp, str.str().c_str(), NULL);
- 
+
   delete scale;
 }
 
@@ -1253,7 +1253,7 @@ void Base::getContourClipCmd()
 {
   FrScale* fr = currentContext->fvcontour().frScale();
   ostringstream str;
-  str << fr->low() << ' ' 
+  str << fr->low() << ' '
       << fr->high() << ends;
   Tcl_AppendResult(interp, str.str().c_str(), NULL);
 }
@@ -1363,7 +1363,7 @@ void Base::getContourScaleCmd()
   case FrScale::IISSCALE:
     Tcl_AppendResult(interp, "linear", NULL);
     break;
-  } 
+  }
 }
 
 void Base::getContourScaleLogCmd()
@@ -1374,7 +1374,7 @@ void Base::getContourScaleLogCmd()
   Tcl_AppendResult(interp, str.str().c_str(), NULL);
 }
 
-void Base::getCoordCmd(const Vector& vv, Coord::CoordSystem out, 
+void Base::getCoordCmd(const Vector& vv, Coord::CoordSystem out,
 		       Coord::SkyFrame sky, Coord::SkyFormat format)
 {
   if (FitsImage* ptr=isInCFits(vv,Coord::CANVAS,NULL))
@@ -1383,7 +1383,7 @@ void Base::getCoordCmd(const Vector& vv, Coord::CoordSystem out,
     Tcl_AppendResult(interp, "0 0", NULL);
 }
 
-// used for Backup 
+// used for Backup
 void Base::getCropCmd(Coord::CoordSystem sys, Coord::SkyFrame sky,
 		      Coord::SkyFormat format)
 {
@@ -1401,7 +1401,7 @@ void Base::getCropCmd(Coord::CoordSystem sys, Coord::SkyFrame sky,
   printFromRef(ptr, ur*ptr->dataToRef, sys, sky, format);
 }
 
-void Base::getCropCenterCmd(Coord::CoordSystem sys, Coord::SkyFrame sky, 
+void Base::getCropCenterCmd(Coord::CoordSystem sys, Coord::SkyFrame sky,
 			    Coord::SkyFormat format, Coord::CoordSystem dcoord,
 			    Coord::DistFormat dist)
 {
@@ -1452,7 +1452,7 @@ void Base::getCrosshairCmd(Coord::InternalSystem sys)
   Tcl_AppendResult(interp, str.str().c_str(), NULL);
 }
 
-void Base::getCrosshairCmd(Coord::CoordSystem sys, Coord::SkyFrame sky, 
+void Base::getCrosshairCmd(Coord::CoordSystem sys, Coord::SkyFrame sky,
 			   Coord::SkyFormat format)
 {
   if (currentContext->cfits)
@@ -1471,7 +1471,7 @@ void Base::getCrosshairStatusCmd()
 
 void Base::getDATASECCmd()
 {
-  if (currentContext->datasec()) 
+  if (currentContext->datasec())
     Tcl_AppendResult(interp, "1", NULL);
   else
     Tcl_AppendResult(interp, "0", NULL);
@@ -1482,8 +1482,9 @@ void Base::getDataValuesCmd(const Vector& vv, Coord::InternalSystem ref,
 {
   Vector rr;
   FitsImage* ptr = isInCFits(vv, ref, &rr);
-  if (!ptr)
+  if (!ptr) {
     return;
+  }
 
   Vector ll = rr - Vector((((Vector&)ss)[0]-1)/2,(((Vector&)ss)[1]-1)/2);
 
@@ -1491,10 +1492,10 @@ void Base::getDataValuesCmd(const Vector& vv, Coord::InternalSystem ref,
   for (int jj=0; jj<((Vector&)ss)[1]; jj++) {
     for (int ii=0; ii<((Vector&)ss)[0]; ii++) {
       Vector dd = (ll+Vector(ii,jj)) * ptr->refToData;
-      FitsBound* params = 
+      FitsBound* params =
 	ptr->getDataParams(currentContext->secMode());
 
-      if (dd[0]>=params->xmin && dd[0]<params->xmax && 
+      if (dd[0]>=params->xmin && dd[0]<params->xmax &&
 	  dd[1]>=params->ymin && dd[1]<params->ymax)
 	Tcl_AppendResult(interp, (char*)ptr->getValue(dd), " ", NULL);
     }
@@ -1502,8 +1503,8 @@ void Base::getDataValuesCmd(const Vector& vv, Coord::InternalSystem ref,
   CLEARSIGBUS
 }
 
-void Base::getDataValuesCmd(int which, const Vector& vv, 
-			    Coord::CoordSystem sys, Coord::SkyFrame sky, 
+void Base::getDataValuesCmd(int which, const Vector& vv,
+			    Coord::CoordSystem sys, Coord::SkyFrame sky,
 			    const Vector& dd, char* var)
 {
   // clear an previous values
@@ -1517,6 +1518,7 @@ void Base::getDataValuesCmd(int which, const Vector& vv,
 
   if (!base) {
     Tcl_SetVar(interp,var,"",0);
+    Tcl_AppendResult(interp, " no data loaded into frame.", NULL);
     result = TCL_ERROR;
     return;
   }
@@ -1538,10 +1540,10 @@ void Base::getDataValuesCmd(int which, const Vector& vv,
       FitsImage* ptr = currentContext->fits;
       while (ptr) {
 	Vector ss = rr * ptr->refToData;
-	FitsBound* params = 
+	FitsBound* params =
 	  ptr->getDataParams(currentContext->secMode());
 
-	if (ss[0]>=params->xmin && ss[0]<params->xmax && 
+	if (ss[0]>=params->xmin && ss[0]<params->xmax &&
 	    ss[1]>=params->ymin && ss[1]<params->ymax) {
 	  Tcl_SetVar2(interp,var,str.str().c_str(),(char*)ptr->getValue(ss),0);
 	  found = 1;
@@ -1562,13 +1564,13 @@ void Base::getFitsNAxesCmd()
   printInteger(currentContext->naxes());
 }
 
-void Base::getFitsCenterCmd(Coord::CoordSystem sys, Coord::SkyFrame sky, 
+void Base::getFitsCenterCmd(Coord::CoordSystem sys, Coord::SkyFrame sky,
 			    Coord::SkyFormat format)
 {
   if (keyContext && keyContext->fits)
-    printFromRef(keyContext->fits, 
+    printFromRef(keyContext->fits,
 		 imageCenter(keyContext->secMode())*
-		 keyContext->fits->imageToRef, 
+		 keyContext->fits->imageToRef,
 		 sys, sky, format);
   else
     Tcl_AppendResult(interp, "0 0", NULL);
@@ -1603,7 +1605,7 @@ void Base::getFitsExtCmd(const Vector& vv, Coord::InternalSystem ref)
     ostringstream str;
     str << ptr->ext() << ends;
     Tcl_AppendResult(interp, str.str().c_str(), NULL);
-  } 
+  }
   else
     Tcl_AppendResult(interp, "", NULL);
 }
@@ -1682,7 +1684,7 @@ void Base::getFitsFileNameCmd(int which, FileNameType type)
     Tcl_AppendResult(interp, "", NULL);
 }
 
-void Base::getFitsFileNameCmd(const Vector& vv, Coord::InternalSystem ref, 
+void Base::getFitsFileNameCmd(const Vector& vv, Coord::InternalSystem ref,
 			      FileNameType type)
 {
   if (FitsImage* ptr=isInCFits(vv,ref,NULL))
@@ -1875,14 +1877,14 @@ void Base::getHistogramCmd(char* xName, char* yName, int num)
   currentContext->bltHist(xName, yName, num);
 }
 
-void Base::getHorzCutCmd(char* xx, char* yy, const Vector& vv, 
-			 Coord::InternalSystem ref, 
+void Base::getHorzCutCmd(char* xx, char* yy, const Vector& vv,
+			 Coord::InternalSystem ref,
 			 int thick, Base::CutMethod method)
 {
   bltCut(xx, yy, Coord::XX, mapToRef(vv,ref), thick, method);
 }
 
-void Base::getHorzCutCmd(char* xx, char* yy, const Vector& vv, 
+void Base::getHorzCutCmd(char* xx, char* yy, const Vector& vv,
 			 Coord::CoordSystem sys, Coord::SkyFrame sky,
 			 int thick, Base::CutMethod method)
 {
@@ -2035,7 +2037,7 @@ void Base::getPixelTableCmd(const Vector& vv, Coord::InternalSystem ref,
 
     str << jj << ',' << ii+1 << ends;
 
-    if (ur[0]>=params->xmin && ll[0]<params->xmax && 
+    if (ur[0]>=params->xmin && ll[0]<params->xmax &&
 	ur[1]>=params->ymin && ll[1]<params->ymax) {
       Vector pt = ((ll+Vector(ii,jj)) * Translate(.5, .5)).round();
       if (pt[0]>params->xmin && pt[0]<=params->xmax) {
@@ -2055,7 +2057,7 @@ void Base::getPixelTableCmd(const Vector& vv, Coord::InternalSystem ref,
     ostringstream str;
     str << hh-jj << ',' << ii << ends;
 
-    if (ur[0]>=params->xmin && ll[0]<params->xmax && 
+    if (ur[0]>=params->xmin && ll[0]<params->xmax &&
 	ur[1]>=params->ymin && ll[1]<params->ymax) {
       Vector pt = ((ll+Vector(ii,jj)) * Translate(.5, .5)).round();
       if (pt[1]>params->ymin && pt[1]<=params->ymax) {
@@ -2076,10 +2078,10 @@ void Base::getPixelTableCmd(const Vector& vv, Coord::InternalSystem ref,
   for (jj=0; jj<hh; jj++) {
     for (ii=0; ii<ww; ii++) {
       Vector pt = ll+Vector(ii,jj);
-      ostringstream str;      
+      ostringstream str;
       str << hh-jj << ',' << ii+1 << ends;
 
-      if (pt[0]>=params->xmin && pt[0]<params->xmax && 
+      if (pt[0]>=params->xmin && pt[0]<params->xmax &&
 	  pt[1]>=params->ymin && pt[1]<params->ymax)
 	Tcl_SetVar2(interp,var,str.str().c_str(),(char*)ptr->getValue(pt),0);
       else
@@ -2159,7 +2161,7 @@ void Base::getValueCmd(const Vector& vv, Coord::InternalSystem sys)
 }
 
 void Base::getVertCutCmd(char* xx, char* yy, const Vector& vv,
-			 Coord::InternalSystem ref, 
+			 Coord::InternalSystem ref,
 			 int thick, Base::CutMethod method)
 {
   bltCut(xx, yy, Coord::YY, mapToRef(vv,ref), thick, method);
@@ -2203,7 +2205,7 @@ void Base::getWCSAlignPointerCmd()
     fitsimageptr_ = NULL;
   fitsimageparentptr_ =this;
 
-  Tcl_AppendResult(interp, (wcsAlign_ ? "1" : "0"), " ", 
+  Tcl_AppendResult(interp, (wcsAlign_ ? "1" : "0"), " ",
 		   coord.coordSystemStr(wcsSystem_), " ",
 		   coord.skyFrameStr(wcsSkyFrame_), NULL);
 }
@@ -2524,7 +2526,7 @@ void Base::magnifierCmd(char* nm, int ww, int hh)
     }
 
     if (!magnifierXImage) {
-      if (!(magnifierXImage = XGetImage(display, magnifierPixmap, 0, 0, 
+      if (!(magnifierXImage = XGetImage(display, magnifierPixmap, 0, 0,
 					magnifierWidth, magnifierHeight,
 					AllPlanes, ZPixmap))){
 	internalError("Unable to Create Magnifier XImage");
@@ -2569,8 +2571,8 @@ void Base::matchCmd(const char* xxname1, const char* yyname1,
 {
   if (keyContext && keyContext->fits)
     keyContext->fits->match(xxname1, yyname1, sys1, sky1,
-			    xxname2, yyname2, sys2, sky2, 
-			    rad, sys, dist, 
+			    xxname2, yyname2, sys2, sky2,
+			    rad, sys, dist,
 			    rrname);
 }
 
@@ -2626,7 +2628,7 @@ void Base::pannerCmd(char* n, int w, int h)
   pannerXImage = NULL;
 
   if (pannerWidth > 0 && pannerHeight > 0) {
-    if (!(pannerPixmap = Tk_GetPixmap(display, Tk_WindowId(tkwin), 
+    if (!(pannerPixmap = Tk_GetPixmap(display, Tk_WindowId(tkwin),
 				      pannerWidth, pannerHeight, depth))) {
       internalError("Unable to Create Panner Pixmap");
       return;
@@ -2644,7 +2646,7 @@ void Base::pannerCmd(char* n, int w, int h)
   update(MATRIX);
 }
 
-void Base::precCmd(int linear, int deg, int hms, int dms, 
+void Base::precCmd(int linear, int deg, int hms, int dms,
 		   int lenlinear, int lendeg, int arcmin, int arcsec,
 		   int angle)
 {
@@ -2662,7 +2664,7 @@ void Base::precCmd(int linear, int deg, int hms, int dms,
 }
 
 // backward compatibility
-void Base::precCmd(int linear, int deg, int hms, int dms, 
+void Base::precCmd(int linear, int deg, int hms, int dms,
 		   int arcmin, int arcsec)
 {
   precLinear_ = linear;
@@ -2874,7 +2876,7 @@ void Base::saveNRRDSocketCmd(int ss, FitsFile::ArchType endian)
     saveNRRD(str, endian);
 }
 
-void Base::saveENVIFileCmd(const char* hdr, const char* fn, 
+void Base::saveENVIFileCmd(const char* hdr, const char* fn,
 			   FitsFile::ArchType endian)
 {
   ofstream str(hdr);
@@ -2893,13 +2895,13 @@ void Base::sliceCmd(double dd, Coord::CoordSystem sys)
 {
   if (!currentContext->fits)
     return;
-  
+
   FitsImage* ptr = currentContext->fits;
   Vector3d cc = Vector3d(ptr->center(),1) * Translate3d(-.5, -.5, -.5);
   Vector3d wcc = ptr->mapFromRef(cc,sys,Coord::ICRS);
   Vector3d oo = ptr->mapToRef(Vector3d(wcc[0],wcc[1],dd),sys,Coord::ICRS);
   Vector3d out = oo * Translate3d(.5, .5, .5);
-  
+
   // IMAGE (ranges 1-n)
   // be sure to round properly
   setSlice(2,int(out[2]+.5));
@@ -3001,7 +3003,7 @@ void Base::warpToCmd(const Vector& vv)
   warpTo(rr);
 }
 
-void Base::wcsCmd(Coord::CoordSystem sys, Coord::SkyFrame sky, 
+void Base::wcsCmd(Coord::CoordSystem sys, Coord::SkyFrame sky,
 		  Coord::SkyFormat format)
 {
   wcsSystem_ = sys;
@@ -3114,7 +3116,7 @@ void Base::wcsAppendTxtCmd(int which, const char* txt)
 
 void Base::wcsResetCmd(int which)
 {
-  if (!currentContext->cfits) 
+  if (!currentContext->cfits)
     return;
 
   FitsImage* rr = findAllFits(which);


### PR DESCRIPTION

This closes #210 
This closes #209 

The view parser has been updated to require `graph` to be followed by `horizontal` or `vertical` ; just `graph` will produce a parse error.   It also fixes the undocumented `view vertgraph` command. 

The `data` command will now return an error if there is no frame. 
