### PR TITLE
Remove DSS from SAO as an option

### DIFF
--- a/ds9/doc/ref/command.html
+++ b/ds9/doc/ref/command.html
@@ -34,7 +34,9 @@
 <a href="#crosshair">crosshair</a><br>
 <a href="#cube">cube</a><br>
 <a href="#cursor">cursor</a><br>
+<!--
 <a href="#dsssao">dsssao</a><br>
+-->
 <a href="#dsseso">dsseso</a><br>
 <a href="#dssstsci">dssstsci</a><br>
 <a href="#envi">envi</a><br>
@@ -685,6 +687,7 @@ $ds9 -cube close</tt><br>
 &nbsp;<br>
 Example:<br>
 $ds9 -cursor 10 10<br></tt>
+<!--
 <p><b><a name="dsssao" id="dsssao"></a>dsssao<br>
 dss<br></b></p>
 <p>Support for Digital Sky Survey at SAO.</p>
@@ -711,6 +714,7 @@ $ds9 -dsssao frame current<br>
 $ds9 -dsssao update frame<br>
 $ds9 -dsssao open<br>
 $ds9 -dsssao close<br></tt>
+-->
 <p><b><a name="dsseso" id="dsseso"></a>dsseso</b></p>
 <p>Support for Digital Sky Survey at ESO.</p>
 <tt>Syntax:<br>

--- a/ds9/doc/ref/samp.html
+++ b/ds9/doc/ref/samp.html
@@ -51,7 +51,9 @@ ds9.set<br>
 <a href="#cube">cube</a><br>
 <a href="#cursor">cursor</a><br>
 <a href="#data">data</a><br>
+<!--
 <a href="#dsssao">dsssao</a><br>
+-->
 <a href="#dsseso">dsseso</a><br>
 <a href="#dssstsci">dssstsci</a><br>
 <a href="#envi">envi</a><br>
@@ -821,6 +823,7 @@ data image 450 520 3 3 yes<br>
 data physical 899 1039 6 6 no<br>
 data fk5 202.47091 47.196811 0.00016516669 0.00016516669 no<br>
 data wcs fk5 13:29:53.018 +47:11:48.52 0.00016516669 0.00016516669 no<br></tt>
+<!--
 <p><b><a name="dsssao" id="dsssao"></a>dsssao<br>
 dss<br></b></p>
 <p>Support for Digital Sky Survey at SAO.</p>
@@ -855,6 +858,7 @@ dsssao frame current<br>
 dsssao update frame<br>
 dsssao open<br>
 dsssao close<br></tt>
+-->
 <p><b><a name="dsseso" id="dsseso"></a>dsseso</b></p>
 <p>Support for Digital Sky Survey at ESO.</p>
 <tt>Syntax:<br>
@@ -1032,7 +1036,7 @@ footprint [cxc|hla]<br>
 <br>
 &nbsp;&nbsp;&nbsp; [save &lt;filename&gt;]<br>
 &nbsp;&nbsp;&nbsp; [export rdb|tsv &lt;filename&gt;]<br>
-<br>  
+<br>
 &nbsp;&nbsp;&nbsp; [coordinate &lt;ra&gt; &lt;dec&gt; &lt;coordsys&gt;]<br>
 &nbsp;&nbsp;&nbsp; [crosshair]<br>
 &nbsp;&nbsp;&nbsp; [current &lt;ref&gt;]<br>

--- a/ds9/doc/ref/xpa.html
+++ b/ds9/doc/ref/xpa.html
@@ -31,7 +31,9 @@
 <a href="#cube">cube</a><br>
 <a href="#cursor">cursor</a><br>
 <a href="#data">data</a><br>
+<!--
 <a href="#dsssao">dsssao</a><br>
+-->
 <a href="#dsseso">dsseso</a><br>
 <a href="#dssstsci">dssstsci</a><br>
 <a href="#envi">envi</a><br>
@@ -764,6 +766,7 @@ $xpaget ds9 data image 450 520 3 3 yes<br>
 $xpaget ds9 data physical 899 1039 6 6 no<br>
 $xpaget ds9 data fk5 202.47091 47.196811 0.00016516669 0.00016516669 no<br>
 $xpaget ds9 data wcs fk5 13:29:53.018 +47:11:48.52 0.00016516669 0.00016516669 no<br></tt>
+<!--
 <p><b><a name="dsssao" id="dsssao"></a>dsssao<br>
 dss<br></b></p>
 <p>Support for Digital Sky Survey at SAO.</p>
@@ -796,6 +799,7 @@ $xpaset -p ds9 dsssao frame current<br>
 $xpaset -p ds9 dsssao update frame<br>
 $xpaset -p ds9 dsssao open<br>
 $xpaset -p ds9 dsssao close</tt><br>
+-->
 <p><b><a name="dsseso" id="dsseso"></a>dsseso</b></p>
 <p>Support for Digital Sky Survey at ESO.</p>
 <tt>Syntax:<br>

--- a/ds9/library/manalysis.tcl
+++ b/ds9/library/manalysis.tcl
@@ -8,11 +8,11 @@ proc AnalysisMainMenu {} {
     global ds9
     global graph
 
-    # WARNING: this is a variable length menu. 
+    # WARNING: this is a variable length menu.
     # Be sure to update ds9(menu,size,analysis)
     ThemeMenu $ds9(mb).analysis
     $ds9(mb).analysis add command -label [msgcat::mc {Pixel Table}] \
-	-command PixelTableDialog 
+	-command PixelTableDialog
     $ds9(mb).analysis add command -label [msgcat::mc {Name Resolution}] \
 	-command NRESDialog
     $ds9(mb).analysis add separator
@@ -96,8 +96,8 @@ proc AnalysisMainMenu {} {
 	-variable block(factor) -value {32 32} -command ChangeBlock
 
     ThemeMenu $ds9(mb).analysis.image
-    $ds9(mb).analysis.image add command \
-	-label {DSS (SAO)} -command SAODialog
+    #~ $ds9(mb).analysis.image add command \
+	#~ -label {DSS (SAO)} -command SAODialog
     $ds9(mb).analysis.image add command \
 	-label {DSS (ESO)} -command ESODialog
     $ds9(mb).analysis.image add command \
@@ -288,7 +288,7 @@ proc PrefsDialogButtonbarAnalysis {f} {
     global pbuttons
 
     ttk::menubutton $f -text [msgcat::mc {Buttonbar}] -menu $f.menu
-    
+
     set m $f.menu
     ThemeMenu $m
     $m add checkbutton -label [msgcat::mc {Contours}] \

--- a/ds9/library/sao.tcl
+++ b/ds9/library/sao.tcl
@@ -137,6 +137,14 @@ taken with the UK Schmidt.
 # Process Cmds
 
 proc ProcessSAOCmd {varname iname} {
+    error "The DSS server at SAO is no longer in service."
+}
+
+proc ProcessSendSAOCmd {proc id param {sock {}} {fn {}}} {
+    error "The DSS server at SAO is no longer in service."
+}
+
+proc ProcessSAOCmd_orig {varname iname} {
     upvar $varname var
     upvar $iname i
 
@@ -148,7 +156,7 @@ proc ProcessSAOCmd {varname iname} {
     incr i [expr $dsssao::yycnt-1]
 }
 
-proc ProcessSendSAOCmd {proc id param {sock {}} {fn {}}} {
+proc ProcessSendSAOCmd_orig {proc id param {sock {}} {fn {}}} {
     global parse
     set parse(proc) $proc
     set parse(id) $id


### PR DESCRIPTION
Since DSS at SAO is no longer supported we remove it as an option.

Technically it is still an option but now returns an error  message saying DSSSAO is no longer in service.

