### PR TITLE
PHOTO: fix problem using xpaget ds9 jpeg|tiff 

### DIFF
--- a/ds9/library/photo.tcl
+++ b/ds9/library/photo.tcl
@@ -12,7 +12,7 @@ proc ImportPhotoFile {fn mode} {
     set loadParam(load,type) photo
 
     # find stdin
-    if {[string range $fn 0 4] == "stdin" || 
+    if {[string range $fn 0 4] == "stdin" ||
 	[string range $fn 0 4] == "STDIN" ||
 	[string range $fn 0 0] == "-"} {
 
@@ -166,15 +166,20 @@ proc ExportPhotoSocket {ch format opt} {
 	return
     }
 
-    switch -- $format {
-	jpeg -
-	tiff {
-	    puts -nonewline $ch [base64::decode $data]
-	}
-	default {
-	    puts -nonewline $ch $data
-	}
-    }
+    # Not sure why this was here. Maybe older version of tkimg
+    # returned image base64 encoded? Does not look to be the case now.
+    #
+    #~ switch -- $format {
+	#~ jpeg -
+	#~ tiff {
+	    #~ puts -nonewline $ch [base64::decode $data]
+	#~ }
+	#~ default {
+	    #~ puts -nonewline $ch $data
+	#~ }
+    #~ }
+
+    puts -nonewline $ch $data
 
     image delete $ph
 }


### PR DESCRIPTION
Running the test suite there was an error reported at the end of `photo.sh`, trying to do

```bash
xpaget ds9 jpeg > foo.jpeg
xpaget ds9 tiff > foo.tiff
```

Only these two file types. One of the errors that was reported was

`XPA$ERROR invalid base64 character "j" at position 1524 (DS9:DS9Test 7f000001:35589)`

Looking into `photo.tcl` there is specific logic in the code that handles `tiff` and `jpeg` outputs as if there are expected to be base64 encoded.  This does not look like it is the case.  Not sure if this is a change to an earlier version of `tkimg` ?

This PR removes the extra `base64::decode` logic and just `puts` the data for all formats.
