### PR TITLE
Simple test of the executable in the CI run

### DIFF
--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -47,7 +47,6 @@ jobs:
       run: |
         make
 
-    # Rely on xvfb to check SAOImageDS9 starts up
-    - name: Check version
+    - name: Check executable
       run: |
-        ./bin/ds9 -version
+        ./bin/ds9 -help


### PR DESCRIPTION
Use `-help` rather than `-version` to check that the executable runs, which means that the CI run does not need to start `Xvfb`.

---

This also tried to add "Add an Intel AARCH (or ARM) build for testing (still just ubuntu)" but there are problems there so it has been shelved for now. 