### PR TITLE
CI: add arm

### DIFF
--- a/.github/scripts/setup.sh
+++ b/.github/scripts/setup.sh
@@ -10,7 +10,7 @@
 
 case $DS9_BUILD_OS in
 
-    "ubuntu-latest")
+    ubuntu-*)
 	source .github/scripts/setup_ubuntu.sh
 	;;
 

--- a/.github/scripts/setup.sh
+++ b/.github/scripts/setup.sh
@@ -14,6 +14,10 @@ case $DS9_BUILD_OS in
 	source .github/scripts/setup_ubuntu.sh
 	;;
 
+    macos-*)
+	source .github/scripts/setup_macos.sh
+	;;
+
     *)
 	echo "** UNKNOWN OS: '$DS9_BUILD_OS'"
 	exit 1

--- a/.github/scripts/setup_macos.sh
+++ b/.github/scripts/setup_macos.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash -e
+#
+# Install any dependencies for building SAOImageDS9 on macOS.
+#
+
+# See https://stackoverflow.com/questions/63648591/how-to-install-x11-before-testing-with-github-actions-for-macos
+#
+brew install --cask xquartz
+
+# Ensure autoheader is available.
+brew install autoconf

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -32,6 +32,9 @@ jobs:
           # - name: Ubuntu 24.04 ARM
           #   os: ubuntu-24.04-arm
 
+          - name: macOS Latest ARM
+            os: macos-latest
+
     steps:
     - name: Checkout Code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # 6.0.2
@@ -44,10 +47,16 @@ jobs:
 
     - name: Configure
       run: |
+        if [ "${RUNNER_OS}" == "macOS" ]; then
+          export PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig:/opt/X11/share/pkgconfig/
+        fi
         unix/configure
 
     - name: Build
       run: |
+        if [ "${RUNNER_OS}" == "macOS" ]; then
+          export PKG_CONFIG_PATH=/opt/X11/lib/pkgconfig:/opt/X11/share/pkgconfig/
+        fi
         make
 
     - name: Check executable

--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -29,6 +29,9 @@ jobs:
           - name: Ubuntu Latest
             os: ubuntu-latest
 
+          # - name: Ubuntu 24.04 ARM
+          #   os: ubuntu-24.04-arm
+
     steps:
     - name: Checkout Code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # 6.0.2


### PR DESCRIPTION
Add a CI run that tests the build on macOS ARM using the unix "flavor".

There is commented-out support for Linux ARM/AARCH since the runner is currently moving from ARM to GitHub, and so development is paused until mid-June (at which point it may become more-obvious whether the apt install problems are temporary or require more work).