### PR TITLE
Gh aqua

### DIFF
--- a/.github/workflows/build-aqua.yml
+++ b/.github/workflows/build-aqua.yml
@@ -1,0 +1,58 @@
+name: build-aqua
+run-name: Build Aqua
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - '*'
+  pull_request:
+
+#Reduces GH Action duplication:
+# Cancels the previous pipeline for this ref it is still running
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-builds:
+    defaults:
+      run:
+        shell: bash
+
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          #~ - name: Ubuntu Latest
+            #~ os: ubuntu-latest
+
+          # - name: Ubuntu 24.04 ARM
+          #   os: ubuntu-24.04-arm
+
+          - name: macOS Latest ARM
+            os: macos-latest
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # 6.0.2
+
+    - name: Install dependencies
+      env:
+        DS9_BUILD_OS: ${{ matrix.os }}
+      run: |
+        source .github/scripts/setup.sh
+
+    - name: Configure
+      run: |
+        macos/configure
+
+    - name: Build
+      run: |
+        make
+
+    - name: Check executable
+      run: |
+        ./bin/ds9 -help

--- a/.github/workflows/build-aqua.yml
+++ b/.github/workflows/build-aqua.yml
@@ -26,12 +26,6 @@ jobs:
     strategy:
       matrix:
         include:
-          #~ - name: Ubuntu Latest
-            #~ os: ubuntu-latest
-
-          # - name: Ubuntu 24.04 ARM
-          #   os: ubuntu-24.04-arm
-
           - name: macOS Latest ARM
             os: macos-latest
 
@@ -51,8 +45,5 @@ jobs:
 
     - name: Build
       run: |
-        make
+        make && make dist
 
-    - name: Check executable
-      run: |
-        ./bin/ds9 -help

--- a/.github/workflows/build-cygwin.yml
+++ b/.github/workflows/build-cygwin.yml
@@ -1,0 +1,233 @@
+name: build-cygwin
+run-name: Build cygwin
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+  pull_request:
+
+#Reduces GH Action duplication:
+# Cancels the previous pipeline for this ref it is still running
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-builds:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: Windows
+            os: windows-latest
+
+    steps:
+      # 1. Configure line endings BEFORE checkout so files land correctly
+      - name: Configure Git line endings
+        shell: pwsh
+        run: git config --global core.autocrlf input
+
+      # 2. Checkout the source code
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      # 3. Install Cygwin and required packages
+      - name: Install Cygwin
+        uses: cygwin/cygwin-install-action@v6
+        with:
+          packages: >-
+            make
+            cmake
+            gcc-core
+            gcc-g++
+            git
+            pkg-config
+            autoconf
+            binutils
+            bzip2
+            coreutils
+            cygwin-devel
+            dash
+            dejavu-fonts
+            diffutils
+            editrights
+            file
+            findutils
+            gawk
+            getent
+            gettext
+            gettext-locale-alias
+            grep
+            groff
+            gzip
+            hostname
+            info
+            ipc-utils
+            less
+            libarchive13
+            libargp
+            libatomic1
+            libattr1
+            libblkid1
+            libbrotlicommon1
+            libbrotlidec1
+            libbz2_1
+            libcharset1
+            libcom_err2
+            libcrypt2
+            libcurl4
+            libdb5.3
+            libedit0
+            libexpat1
+            libfdisk1
+            libffi8
+            libfido2
+            libfontconfig-common
+            libfontconfig1
+            libfreetype6
+            libgc1
+            libgcc1
+            libgcrypt-devel
+            libgcrypt20
+            libgdbm6
+            libgdbm_compat4
+            libgmp10
+            libgomp1
+            libgpg-error-devel
+            libgpg-error0
+            libgsasl-common
+            libgsasl18
+            libgssapi_krb5_2
+            libguile3.0_1
+            libiconv-devel
+            libiconv2
+            libidn2_0
+            libintl-devel
+            libintl8
+            libisl23
+            libjsoncpp26
+            libk5crypto3
+            libkrb5_3
+            libkrb5support0
+            liblz4_1
+            liblzma-devel
+            liblzma5
+            liblzo2_2
+            libmpc3
+            libmpfr6
+            libncursesw10
+            libnghttp2_14
+            libntlm0
+            libopenldap2_4_2
+            libp11-kit0
+            libpcre2_8_0
+            libpipeline1
+            libpkgconf7
+            libpng16
+            libpopt0
+            libpsl5
+            libquadmath0
+            libreadline8
+            librhash0
+            libsasl2_3
+            libsigsegv2
+            libsmartcols1
+            libsqlite3_0
+            libssh2_1
+            libssl3
+            libstdc++6
+            libtasn1_6
+            libuchardet0
+            libunistring5
+            libuuid1
+            libuv1
+            libX11-devel
+            libX11_6
+            libXau-devel
+            libXau6
+            libxcb-devel
+            libxcb1
+            libXdmcp-devel
+            libXdmcp6
+            libXext-devel
+            libXext6
+            libXft2
+            libxml2
+            libxml2-devel
+            libXrandr-devel
+            libXrandr2
+            libXrender-devel
+            libXrender1
+            libxslt
+            libxslt-devel
+            libXss1
+            libxxhash0
+            libzip-devel
+            libzip5
+            libzstd1
+            login
+            m4
+            man-db
+            mingw64-x86_64-binutils
+            mingw64-x86_64-gcc-core
+            mingw64-x86_64-gcc-g++
+            mingw64-x86_64-headers
+            mingw64-x86_64-libxml2
+            mingw64-x86_64-libxslt
+            mingw64-x86_64-runtime
+            mingw64-x86_64-tcl
+            mingw64-x86_64-win-iconv
+            mingw64-x86_64-windows-default-manifest
+            mingw64-x86_64-winpthreads
+            mingw64-x86_64-xz
+            mingw64-x86_64-zlib
+            mintty
+            ncurses
+            openssh
+            openssl
+            p11-kit
+            p11-kit-trust
+            perl
+            perl-XML-Parser
+            perl_autorebase
+            perl_base
+            pkgconf
+            rebase
+            rsync
+            run
+            sed
+            tar
+            tcl
+            tcl-devel
+            tcl-tk
+            tcl-tk-devel
+            terminfo
+            tzcode
+            tzdata
+            unzip
+            util-linux
+            vim-minimal
+            w32api-headers
+            w32api-runtime
+            which
+            windows-default-manifest
+            xorgproto
+            xz
+            zip
+            zlib
+            zlib-devel
+            zlib0
+            zstd
+
+      # 4. Build inside Cygwin
+      - name: Run Cygwin Script
+        # Use the absolute path to Cygwin bash to avoid accidentally
+        # picking up Git-for-Windows bash from the PATH.
+        shell: bash -eo pipefail {0}
+        run: |
+          # Need to && cmds and tack on echo to avoid windows newlines
+          chmod +x ./win/configure && ./win/configure && make && echo ok

--- a/ds9/make.include
+++ b/ds9/make.include
@@ -24,7 +24,7 @@ SRCL = $(wildcard $(prefix)/ds9/parsers/*.fcl)
 
 $(LIBDIR)/library : $(SRCP:.tac=.tcl) $(SRCP:.tac=.tab.tcl) $(SRCL:.fcl=.tcl) $(prefix)/ds9/library/*.tcl
 	mkdir -p "$@"
-	cp -prf $? "$@"
+	cp -rf $? "$@"
 # must do it this way for win
 	cd "$@"; \
 	echo "pkg_mkIndex . *.tcl; exit" | $(TCLSH_PROG)
@@ -33,25 +33,25 @@ $(LIBDIR)/library : $(SRCP:.tac=.tcl) $(SRCP:.tac=.tab.tcl) $(SRCL:.fcl=.tcl) $(
 #--------------------------support
 
 $(LIBDIR)/msgs : $(prefix)/ds9/msgs
-	cp -prf $? "$@"
+	cp -rf $? "$@"
 
 $(LIBDIR)/doc : $(prefix)/ds9/doc
-	cp -prf $? "$@"
+	cp -rf $? "$@"
 
 $(LIBDIR)/cmaps : $(prefix)/ds9/cmaps
-	cp -prf $? "$@"
+	cp -rf $? "$@"
 
 $(LIBDIR)/template : $(prefix)/ds9/template
-	cp -prf $? "$@"
+	cp -rf $? "$@"
 
 $(LIBDIR)/icons : $(prefix)/ds9/icons
-	cp -prf $? "$@"
+	cp -rf $? "$@"
 
 #--------------------------tls
 
 $(LIBDIR)/tls	: $(prefix)/tls/library/tls.tcl
 	mkdir -p "$@"
-	cp -prf $? "$@"
+	cp -rf $? "$@"
 # must do it this way for win
 	cd "$@"; \
 	echo "pkg_mkIndex . *.tcl; exit" | $(TCLSH_PROG)
@@ -68,7 +68,7 @@ $(LIBDIR)/tkblt	: $(prefix)/tkblt/library/*.tcl
 #--------------------------tkcon
 
 $(LIBDIR)/tkcon	: $(prefix)/tkcon
-	cp -prf $? "$@"
+	cp -rf $? "$@"
 # must do it this way for win
 	cd "$@"; \
 	echo "pkg_mkIndex . *.tcl; exit" | $(TCLSH_PROG)
@@ -76,24 +76,24 @@ $(LIBDIR)/tkcon	: $(prefix)/tkcon
 #--------------------------tcllib
 
 $(LIBDIR)/base64: $(prefix)/tcllib/modules/base64
-	cp -prf $? "$@"
+	cp -rf $? "$@"
 
 $(LIBDIR)/ftp	: $(prefix)/tcllib/modules/ftp
-	cp -prf $? "$@"
+	cp -rf $? "$@"
 
 $(LIBDIR)/log	: $(prefix)/tcllib/modules/log
-	cp -prf $? "$@"
+	cp -rf $? "$@"
 
 $(LIBDIR)/textutil: $(prefix)/tcllib/modules/textutil
-	cp -prf $? "$@"
+	cp -rf $? "$@"
 
 $(LIBDIR)/math	: $(prefix)/tcllib/modules/math
-	cp -prf $? "$@"
+	cp -rf $? "$@"
 
 #--------------------------tklib
 
 $(LIBDIR)/tooltip: $(prefix)/tklib/modules/tooltip
-	cp -prf $? "$@"
+	cp -rf $? "$@"
 
 #--------------------------distclean
 

--- a/ds9/win/Makefile.in
+++ b/ds9/win/Makefile.in
@@ -157,13 +157,13 @@ PREQS	= \
 .PHONY	: debug
 
 $(APPDIR)/ds9.exe : ds9Base.exe $(PREQS)
-	cp -p ds9base.exe ds9.exe
+	cp -f ds9base.exe ds9.exe
 	strip ds9.exe
-	cp -p ds9.exe $(APPDIR)/.
+	cp -f ds9.exe $(APPDIR)/.
 
 debug	: ds9Base.exe $(PREQS)
 	mv ds9base.exe ds9.exe
-	cp -p ds9.exe $(APPDIR)/.
+	cp -f ds9.exe $(APPDIR)/.
 
 ds9Base.exe: $(OBJS) $(LLIBS)
 	$(RM) $@
@@ -196,40 +196,40 @@ $(APPDIR):
 	mkdir -p $@
 
 $(APPDIR)/tcl$(TCL_VERSION) : $(prefix)/lib/tcl$(TCL_VERSION)
-	cp -pr $? $@
+	cp -fr $? $@
 
 $(APPDIR)/tcl8 : $(prefix)/lib/tcl8
-	cp -pr $? $@
+	cp -fr $? $@
 
 $(APPDIR)/tk$(TCL_VERSION) : $(prefix)/lib/tk$(TCL_VERSION)
-	cp -pr $? $@
+	cp -fr $? $@
 
 #--------------------------awthemes
 
 $(APPDIR)/awthemes: $(prefix)/awthemes
-	cp -prf $? "$@"
+	cp -fr $? "$@"
 
 #--------------------------ttkthemes
 
 $(APPDIR)/ttkthemes: $(prefix)/ttkthemes/ttkthemes/themes
-	cp -prf $? "$@"
+	cp -fr $? "$@"
 
 #--------------------------scidthemes
 
 $(APPDIR)/scidthemes: $(prefix)/scidthemes
-	cp -prf $? "$@"
+	cp -fr $? "$@"
 
 
 # ------------------ssl
 $(APPDIR)/ssl: $(prefix)/openssl
 	mkdir "$@"
-	cp -pvf "$(prefix)/certifi/certifi/cacert.pem" "$@"
+	cp -fv "$(prefix)/certifi/certifi/cacert.pem" "$@"
 
 $(APPDIR)/xpans.exe: $(bindir)/xpans.exe
-	cp -p $? $@
+	cp -f $? $@
 
 $(APPDIR)/install.vbs: install.vbs
-	cp -p $? $@
+	cp -f $? $@
 
 $(APPDIR)/tcc: $(prefix)/compilers/tcc-0.9.25-win32-bin.zip
 	$(RM) -rf $@

--- a/make.include
+++ b/make.include
@@ -204,7 +204,7 @@ tclxmlrpc/Makefile :
 tls	: tls/Makefile
 	@echo ""
 	@echo "*** $@ ***"
-	$(MAKE) -C tls install
+	$(MAKE) -C tls install-binaries
 
 tls/Makefile :
 	@echo ""


### PR DESCRIPTION
The aqua build was pretty trivial given @DougBurke 's work on Unix.

The cygwin build was a PITA. Lots of problems with Windows newline (\r) fouling things up. Final "solution" was to tack on an "echo ok" command at the end so it would just print that \r without trying to use is as part of the command.

Two other issues came up with cygwin
- The `tls` module failed when trying to build the docs due to "()" in various Windows environment variable names (eg `PATH=...:C:\Program Files (x86)` . Changed the build target from `make install` to `make binaries-install` to skip building the docs.
- The cygwin action has some user id/name conflict with the windows VM. Doing a `cp -p` would fail due to permission problems. Dropped the `-p`.  Note: this is also the cause of the final warning in the post build step where git complains about unknown users/whatnot. 