### PR TITLE
Fix reading of lossless compressed GZIP floating points

### DIFF
--- a/fitsy/gzip.C
+++ b/fitsy/gzip.C
@@ -281,17 +281,15 @@ template <class T> int FitsGzipm<T>::compressed(T* dest, char* sptr,
 			*((int*)obuf+ll) = u.i;
 		      }
 		      // very carefull about type conversions
+		      // a floating point image with no scaling holds raw IEEE
+		      // floats (lossless GZIP); otherwise the tile holds quantized
+		      // integers that getValue() dequantizes
 		      T val =0;
-		      switch (FitsCompressm<T>::quantize_) {
-		      case FitsCompress::NONE:
+		      if (FitsCompressm<T>::quantize_ == FitsCompress::NONE ||
+			  (FitsCompressm<T>::bitpix_ < 0 && !FitsCompressm<T>::hasScaling_))
 			val = FitsCompressm<T>::getValue((float*)obuf+ll,zs,zz,blank);
-			break;
-		      case FitsCompress::NODITHER:
-		      case FitsCompress::SUBDITHER1:
-		      case FitsCompress::SUBDITHER2:
+		      else
 			val = FitsCompressm<T>::getValue((int*)obuf+ll,zs,zz,blank);
-			break;
-		      }
 		      dest[FitsCompressm<T>::calcIndex(xx)] = val;
 		    }
     break;
@@ -325,17 +323,15 @@ template <class T> int FitsGzipm<T>::compressed(T* dest, char* sptr,
 			*((long long*)obuf+ll) = u.i;
 		      }
 		      // very carefull about type conversions
+		      // a floating point image with no scaling holds raw IEEE
+		      // doubles (lossless GZIP); otherwise the tile holds quantized
+		      // integers that getValue() dequantizes
 		      T val =0;
-		      switch (FitsCompressm<T>::quantize_) {
-		      case FitsCompress::NONE:
+		      if (FitsCompressm<T>::quantize_ == FitsCompress::NONE ||
+			  (FitsCompressm<T>::bitpix_ < 0 && !FitsCompressm<T>::hasScaling_))
 			val = FitsCompressm<T>::getValue((double*)obuf+ll,zs,zz,blank);
-			break;
-		      case FitsCompress::NODITHER:
-		      case FitsCompress::SUBDITHER1:
-		      case FitsCompress::SUBDITHER2:
+		      else
 			val = FitsCompressm<T>::getValue((long long*)obuf+ll,zs,zz,blank);
-			break;
-		      }
 		      dest[FitsCompressm<T>::calcIndex(xx)] = val;
 		    }
     break;


### PR DESCRIPTION
The code was previously assuming any dither keyword meant that the data were quantized to integers and was therefore treating the floats as integers.

The header was:

```
XTENSION= 'BINTABLE'           / binary table extension
BITPIX  =                    8 / array data type
NAXIS   =                    2 / number of array dimensions
NAXIS1  =                    8 / width of table in bytes
NAXIS2  =                  101 / number of rows in table
PCOUNT  =                41552 / number of group parameters
GCOUNT  =                    1 / number of groups
TFIELDS =                    1 / number of fields in each row
TTYPE1  = 'COMPRESSED_DATA'
TFORM1  = '1PB(427)'
ZIMAGE  =                    T / extension contains compressed image
ZTENSION= 'IMAGE   '           / Image extension
ZBITPIX =                  -32 / array data type
ZNAXIS  =                    2 / number of array dimensions
ZNAXIS1 =                  101
ZNAXIS2 =                  101
ZPCOUNT =                    0 / number of parameters
ZGCOUNT =                    1 / number of groups
ZTILE1  =                  101 / size of tiles to be compressed
ZTILE2  =                    1 / size of tiles to be compressed
ZCMPTYPE= 'GZIP_2  '           / compression algorithm
ZNAME1  = 'NOISEBIT'           / floating point quantization level
ZVAL1   =                  0.0 / floating point quantization level
ZQUANTIZ= 'NO_DITHER'          / No dithering during quantization
EXTNAME = 'IMAGE   '           / name of this binary table extension
```

And the ZQUANTIZ header was treating the data as if it was quantized regardless of the header value declaring that there was no quantization and the ZBITPIX being floats. This meant that some Rubin images had values of +/- billions instead of the real values of tens of thousands.