### PR TITLE
Illustrate rotate shapes

### DIFF
--- a/ds9/library/illustratebase.tcl
+++ b/ds9/library/illustratebase.tcl
@@ -53,8 +53,20 @@ proc IllustrateBaseDup {type param} {
     
     switch $type {
 	circle -
-	ellipse {set tt oval}
-	box {set tt rectangle}
+	ellipse {
+	    if {[llength [lindex $param 0]] > 4} {
+		set tt polygon
+	    } else {
+		set tt oval
+	    }
+	}
+	box {
+	    if {[llength [lindex $param 0]] > 4} {
+		set tt polygon
+	    } else {
+		set tt rectangle
+	    }
+	}
     }
 
     foreach {coords color fill width dash} $param {
@@ -70,6 +82,44 @@ proc IllustrateBaseDup {type param} {
     IllustrateBaseCreateHandles $id [$ds9(canvas) itemcget $id -outline]
 
     return $id
+}
+
+proc IllustrateBaseRotatedCoords {xc yc rr1 rr2 angle points} {
+    set aa [expr {$angle*acos(-1)/180.}]
+    set ca [expr {cos($aa)}]
+    set sa [expr {sin($aa)}]
+    set coords {}
+
+    if {$points == 4} {
+	set local [list -$rr1 -$rr2 $rr1 -$rr2 $rr1 $rr2 -$rr1 $rr2]
+	foreach {dx dy} $local {
+	    lappend coords \
+		[expr {$xc + $dx*$ca - $dy*$sa}] \
+		[expr {$yc + $dx*$sa + $dy*$ca}]
+	}
+    } else {
+	for {set ii 0} {$ii < $points} {incr ii} {
+	    set tt [expr {2*acos(-1)*$ii/$points}]
+	    set dx [expr {$rr1*cos($tt)}]
+	    set dy [expr {$rr2*sin($tt)}]
+	    lappend coords \
+		[expr {$xc + $dx*$ca - $dy*$sa}] \
+		[expr {$yc + $dx*$sa + $dy*$ca}]
+	}
+    }
+
+    return $coords
+}
+
+proc IllustrateBaseAngleProps {id angle} {
+    set rr [IllustrateBaseListProps $id]
+    if {abs($angle) > .000001} {
+	if {$rr == {}} {
+	    append rr " #"
+	}
+	append rr " angle = $angle"
+    }
+    return $rr
 }
 
 proc IllustrateBaseCreateHandles {id color} {
@@ -401,5 +451,4 @@ proc IllustrateBaseWidthCB {id} {
 	set var(dash) 0
     }
 }
-
 

--- a/ds9/library/illustratebase.tcl
+++ b/ds9/library/illustratebase.tcl
@@ -111,6 +111,18 @@ proc IllustrateBaseRotatedCoords {xc yc rr1 rr2 angle points} {
     return $coords
 }
 
+proc IllustrateBaseRotatedRadii {xc yc xx yy angle} {
+    set aa [expr {$angle*acos(-1)/180.}]
+    set ca [expr {cos($aa)}]
+    set sa [expr {sin($aa)}]
+    set dx [expr {$xx-$xc}]
+    set dy [expr {$yy-$yc}]
+
+    set rr1 [expr {abs($dx*$ca + $dy*$sa)}]
+    set rr2 [expr {abs(-$dx*$sa + $dy*$ca)}]
+    return [list $rr1 $rr2]
+}
+
 proc IllustrateBaseAngleProps {id angle} {
     set rr [IllustrateBaseListProps $id]
     if {abs($angle) > .000001} {
@@ -451,4 +463,3 @@ proc IllustrateBaseWidthCB {id} {
 	set var(dash) 0
     }
 }
-

--- a/ds9/library/illustratebase.tcl
+++ b/ds9/library/illustratebase.tcl
@@ -125,12 +125,24 @@ proc IllustrateBaseRotatedRadii {xc yc xx yy angle} {
 
 proc IllustrateBaseAngleProps {id angle} {
     set rr [IllustrateBaseListProps $id]
-    if {abs($angle) > .000001} {
+    if {abs($angle) > 1.0e-6} {
 	if {$rr == {}} {
 	    append rr " #"
 	}
-	append rr " angle = $angle"
+	append rr " angle = [IllustrateBaseFormatNumber $angle]"
     }
+    return $rr
+}
+
+proc IllustrateBaseFormatNumber {value} {
+    set rounded [expr {round($value)}]
+    if {abs($value-$rounded) < 1.0e-6} {
+	return [format %.1f [expr {double($rounded)}]]
+    }
+
+    set rr [format %.6f $value]
+    set rr [string trimright $rr 0]
+    set rr [string trimright $rr .]
     return $rr
 }
 

--- a/ds9/library/illustratebox.tcl
+++ b/ds9/library/illustratebox.tcl
@@ -58,8 +58,13 @@ proc IllustrateBoxList {id} {
     global ds9
 
     foreach {xc yc r1 r2 angle} [IllustrateBoxGeometry $id] {}
-    
-    return "box $xc $yc $r1 $r2 [IllustrateBaseAngleProps $id $angle]"
+    set rr [format "box %s %s %s %s" \
+		[IllustrateBaseFormatNumber $xc] \
+		[IllustrateBaseFormatNumber $yc] \
+		[IllustrateBaseFormatNumber $r1] \
+		[IllustrateBaseFormatNumber $r2]]
+    append rr [IllustrateBaseAngleProps $id $angle]
+    return $rr
 }
 
 # Dialog
@@ -195,9 +200,9 @@ proc IllustrateBoxEditCB {id} {
     global ds9
 
     foreach {xc yc rr1 rr2 angle} [IllustrateBoxGeometry $var(id)] {}
-    set var(xc) $xc
-    set var(yc) $yc
-    set var(rr1) $rr1
-    set var(rr2) $rr2
-    set var(angle) $angle
+    set var(xc) [IllustrateBaseFormatNumber $xc]
+    set var(yc) [IllustrateBaseFormatNumber $yc]
+    set var(rr1) [IllustrateBaseFormatNumber $rr1]
+    set var(rr2) [IllustrateBaseFormatNumber $rr2]
+    set var(angle) [IllustrateBaseFormatNumber $angle]
 }

--- a/ds9/library/illustratebox.tcl
+++ b/ds9/library/illustratebox.tcl
@@ -47,21 +47,9 @@ proc IllustrateBoxDefault {id} {
 
 proc IllustrateBoxEdit {id xx yy} {
     global ds9
-    global iillustrate
 
     foreach {xc yc rr1 rr2 angle} [IllustrateBoxGeometry $id] {}
-    foreach {x1 y1 x2 y2} [$ds9(canvas) bbox $id] {}
-    switch $iillustrate(handle) {
-	1 {set x1 $xx; set y1 $yy}
-	2 {set x2 $xx; set y1 $yy}
-	3 {set x2 $xx; set y2 $yy}
-	4 {set x1 $xx; set y2 $yy}
-    }
-
-    set xc [expr {($x2-$x1)/2+$x1}]
-    set yc [expr {($y2-$y1)/2+$y1}]
-    set rr1 [expr {abs($x2-$x1)/2}]
-    set rr2 [expr {abs($y2-$y1)/2}]
+    foreach {rr1 rr2} [IllustrateBaseRotatedRadii $xc $yc $xx $yy $angle] {}
     $ds9(canvas) coords $id \
 	[IllustrateBaseRotatedCoords $xc $yc $rr1 $rr2 $angle 4]
 }

--- a/ds9/library/illustratebox.tcl
+++ b/ds9/library/illustratebox.tcl
@@ -4,7 +4,7 @@
 
 package provide DS9 1.0
 
-proc IllustrateBoxCreate {xx yy rr1 rr2 color fill width dash} {
+proc IllustrateBoxCreate {xx yy rr1 rr2 color fill width dash {angle 0}} {
     global ds9
     global illustrate
 
@@ -19,9 +19,8 @@ proc IllustrateBoxCreate {xx yy rr1 rr2 color fill width dash} {
 	set dashlist {}
     }
 
-    set id [$ds9(canvas) create rectangle \
-		[expr $xx-$rr1] [expr $yy-$rr2] \
-		[expr $xx+$rr1] [expr $yy+$rr2] \
+    set id [$ds9(canvas) create polygon \
+		[IllustrateBaseRotatedCoords $xx $yy $rr1 $rr2 $angle 4] \
 		-outline $color \
 		-fill $fillcolor \
 		-width $width \
@@ -41,8 +40,7 @@ proc IllustrateBoxDefault {id} {
     set rr2 [expr $pillustrate(box,radius2)/2]
 
     $ds9(canvas) coords $id \
-		[expr $xx-$rr1] [expr $yy-$rr2] \
-		[expr $xx+$rr1] [expr $yy+$rr2]
+	[IllustrateBaseRotatedCoords $xx $yy $rr1 $rr2 0 4]
 }
 
 # BaseDup
@@ -51,25 +49,29 @@ proc IllustrateBoxEdit {id xx yy} {
     global ds9
     global iillustrate
 
-    foreach {x1 y1 x2 y2} [$ds9(canvas) coords $id] {}
+    foreach {xc yc rr1 rr2 angle} [IllustrateBoxGeometry $id] {}
+    foreach {x1 y1 x2 y2} [$ds9(canvas) bbox $id] {}
     switch $iillustrate(handle) {
-	1 {$ds9(canvas) coords $id $xx $yy $x2 $y2}
-	2 {$ds9(canvas) coords $id $x1 $yy $xx $y2}
-	3 {$ds9(canvas) coords $id $x1 $y1 $xx $yy}
-	4 {$ds9(canvas) coords $id $xx $y1 $x2 $yy}
+	1 {set x1 $xx; set y1 $yy}
+	2 {set x2 $xx; set y1 $yy}
+	3 {set x2 $xx; set y2 $yy}
+	4 {set x1 $xx; set y2 $yy}
     }
+
+    set xc [expr {($x2-$x1)/2+$x1}]
+    set yc [expr {($y2-$y1)/2+$y1}]
+    set rr1 [expr {abs($x2-$x1)/2}]
+    set rr2 [expr {abs($y2-$y1)/2}]
+    $ds9(canvas) coords $id \
+	[IllustrateBaseRotatedCoords $xc $yc $rr1 $rr2 $angle 4]
 }
 
 proc IllustrateBoxList {id} {
     global ds9
 
-    foreach {x1 y1 x2 y2} [$ds9(canvas) coords $id] {}
-    set xc [expr ($x2-$x1)/2+$x1]
-    set yc [expr ($y2-$y1)/2+$y1]
-    set r1 [expr ($x2-$x1)/2]
-    set r2 [expr ($y2-$y1)/2]
+    foreach {xc yc r1 r2 angle} [IllustrateBoxGeometry $id] {}
     
-    return "box $xc $yc $r1 $r2 [IllustrateBaseListProps $id]"
+    return "box $xc $yc $r1 $r2 [IllustrateBaseAngleProps $id $angle]"
 }
 
 # Dialog
@@ -96,6 +98,7 @@ proc IllustrateBoxDialog {id} {
     # variables
     set var(rr1) 0
     set var(rr2) 0
+    set var(angle) 0
 
     # proc
     set var(proc,apply) IllustrateBoxApply
@@ -108,6 +111,12 @@ proc IllustrateBoxDialog {id} {
     ttk::entry $f.radius1 -textvariable ${varname}(rr1) -width 13 
     ttk::entry $f.radius2 -textvariable ${varname}(rr2) -width 13 
     grid $f.tradius $f.radius1 $f.radius2 -padx 2 -pady 2 -sticky w
+
+    # Angle
+    ttk::label $f.tangle -text [msgcat::mc {Angle}]
+    ttk::entry $f.angle -textvariable ${varname}(angle) -width 13
+    ttk::label $f.uangle -text [msgcat::mc {Degrees}]
+    grid $f.tangle $f.angle $f.uangle -padx 2 -pady 2 -sticky w
 
     # init
     IllustrateBoxEditCB $var(id)
@@ -129,13 +138,57 @@ proc IllustrateBoxApply {varname} {
 	set yc $var(yc)
 	set rr1 $var(rr1)
 	set rr2 $var(rr2)
+	set angle $var(angle)
 
 	$ds9(canvas) coords $var(id) \
-	    [expr $xc-$rr1] [expr $yc-$rr2] \
-	    [expr $xc+$rr1] [expr $yc+$rr2]
+	    [IllustrateBaseRotatedCoords $xc $yc $rr1 $rr2 $angle 4]
 
 	IllustrateBaseUpdateHandle $var(id)
     }
+}
+
+proc IllustrateBoxRotate {id xx yy} {
+    global ds9
+    global iillustrate
+
+    foreach {xc yc rr1 rr2 angle} [IllustrateBoxGeometry $id] {}
+    set dx [expr {$xx-$xc}]
+    set dy [expr {$yy-$yc}]
+    set aa [expr {atan2($dy,$dx)*180./acos(-1)}]
+
+    switch $iillustrate(handle) {
+	1 {set bx -$rr1; set by -$rr2}
+	2 {set bx $rr1; set by -$rr2}
+	3 {set bx $rr1; set by $rr2}
+	4 {set bx -$rr1; set by $rr2}
+    }
+    set bb [expr {atan2($by,$bx)*180./acos(-1)}]
+    set angle [expr {$aa-$bb}]
+
+    $ds9(canvas) coords $id \
+	[IllustrateBaseRotatedCoords $xc $yc $rr1 $rr2 $angle 4]
+}
+
+proc IllustrateBoxGeometry {id} {
+    global ds9
+
+    set coords [$ds9(canvas) coords $id]
+    if {[llength $coords] == 4} {
+	foreach {x1 y1 x2 y2} $coords {}
+	set xc [expr {($x2-$x1)/2+$x1}]
+	set yc [expr {($y2-$y1)/2+$y1}]
+	set rr1 [expr {abs($x2-$x1)/2}]
+	set rr2 [expr {abs($y2-$y1)/2}]
+	return [list $xc $yc $rr1 $rr2 0]
+    }
+
+    foreach {x1 y1 x2 y2 x3 y3 x4 y4} $coords {}
+    set xc [expr {($x1+$x2+$x3+$x4)/4.}]
+    set yc [expr {($y1+$y2+$y3+$y4)/4.}]
+    set rr1 [expr {sqrt(($x2-$x1)*($x2-$x1)+($y2-$y1)*($y2-$y1))/2.}]
+    set rr2 [expr {sqrt(($x4-$x1)*($x4-$x1)+($y4-$y1)*($y4-$y1))/2.}]
+    set angle [expr {atan2($y2-$y1,$x2-$x1)*180./acos(-1)}]
+    return [list $xc $yc $rr1 $rr2 $angle]
 }
 
 # callbacks
@@ -153,9 +206,10 @@ proc IllustrateBoxEditCB {id} {
 
     global ds9
 
-    foreach {x1 y1 x2 y2} [$ds9(canvas) coords $var(id)] {}
-    set var(xc) [expr ($x2-$x1)/2+$x1]
-    set var(yc) [expr ($y2-$y1)/2+$y1]
-    set var(rr1) [expr ($x2-$x1)/2]
-    set var(rr2) [expr ($y2-$y1)/2]
+    foreach {xc yc rr1 rr2 angle} [IllustrateBoxGeometry $var(id)] {}
+    set var(xc) $xc
+    set var(yc) $yc
+    set var(rr1) $rr1
+    set var(rr2) $rr2
+    set var(angle) $angle
 }

--- a/ds9/library/illustrateellipse.tcl
+++ b/ds9/library/illustrateellipse.tcl
@@ -4,7 +4,7 @@
 
 package provide DS9 1.0
 
-proc IllustrateEllipseCreate {xx yy rr1 rr2 color fill width dash} {
+proc IllustrateEllipseCreate {xx yy rr1 rr2 color fill width dash {angle 0}} {
     global ds9
     global illustrate
 
@@ -19,9 +19,8 @@ proc IllustrateEllipseCreate {xx yy rr1 rr2 color fill width dash} {
 	set dashlist {}
     }
 
-    set id [$ds9(canvas) create oval \
-		[expr $xx-$rr1] [expr $yy-$rr2] \
-		[expr $xx+$rr1] [expr $yy+$rr2] \
+    set id [$ds9(canvas) create polygon \
+		[IllustrateBaseRotatedCoords $xx $yy $rr1 $rr2 $angle 72] \
 		-outline $color \
 		-fill $fillcolor \
 		-width $width \
@@ -41,8 +40,7 @@ proc IllustrateEllipseDefault {id} {
     set rr2 $pillustrate(ellipse,radius2)
     
     $ds9(canvas) coords $id \
-	[expr $xx-$rr1] [expr $yy-$rr2] \
-	[expr $xx+$rr1] [expr $yy+$rr2]
+	[IllustrateBaseRotatedCoords $xx $yy $rr1 $rr2 0 72]
 }
 
 # BaseDup
@@ -51,25 +49,29 @@ proc IllustrateEllipseEdit {id xx yy} {
     global ds9
     global iillustrate
 
-    foreach {x1 y1 x2 y2} [$ds9(canvas) coords $id] {}
+    foreach {xc yc rr1 rr2 angle} [IllustrateEllipseGeometry $id] {}
+    foreach {x1 y1 x2 y2} [$ds9(canvas) bbox $id] {}
     switch $iillustrate(handle) {
-	1 {$ds9(canvas) coords $id $xx $yy $x2 $y2}
-	2 {$ds9(canvas) coords $id $x1 $yy $xx $y2}
-	3 {$ds9(canvas) coords $id $x1 $y1 $xx $yy}
-	4 {$ds9(canvas) coords $id $xx $y1 $x2 $yy}
+	1 {set x1 $xx; set y1 $yy}
+	2 {set x2 $xx; set y1 $yy}
+	3 {set x2 $xx; set y2 $yy}
+	4 {set x1 $xx; set y2 $yy}
     }
+
+    set xc [expr {($x2-$x1)/2+$x1}]
+    set yc [expr {($y2-$y1)/2+$y1}]
+    set rr1 [expr {abs($x2-$x1)/2}]
+    set rr2 [expr {abs($y2-$y1)/2}]
+    $ds9(canvas) coords $id \
+	[IllustrateBaseRotatedCoords $xc $yc $rr1 $rr2 $angle 72]
 }
 
 proc IllustrateEllipseList {id} {
     global ds9
 
-    foreach {x1 y1 x2 y2} [$ds9(canvas) coords $id] {}
-    set xc [expr ($x2-$x1)/2+$x1]
-    set yc [expr ($y2-$y1)/2+$y1]
-    set r1 [expr ($x2-$x1)/2]
-    set r2 [expr ($y2-$y1)/2]
+    foreach {xc yc r1 r2 angle} [IllustrateEllipseGeometry $id] {}
     
-    return "ellipse $xc $yc $r1 $r2 [IllustrateBaseListProps $id]"
+    return "ellipse $xc $yc $r1 $r2 [IllustrateBaseAngleProps $id $angle]"
 }
 
 # Dialog
@@ -96,6 +98,7 @@ proc IllustrateEllipseDialog {id} {
     # variables
     set var(rr1) 0
     set var(rr2) 0
+    set var(angle) 0
 
     # proc
     set var(proc,apply) IllustrateEllipseApply
@@ -108,6 +111,12 @@ proc IllustrateEllipseDialog {id} {
     ttk::entry $f.radius1 -textvariable ${varname}(rr1) -width 13 
     ttk::entry $f.radius2 -textvariable ${varname}(rr2) -width 13 
     grid $f.tradius $f.radius1 $f.radius2 -padx 2 -pady 2 -sticky w
+
+    # Angle
+    ttk::label $f.tangle -text [msgcat::mc {Angle}]
+    ttk::entry $f.angle -textvariable ${varname}(angle) -width 13
+    ttk::label $f.uangle -text [msgcat::mc {Degrees}]
+    grid $f.tangle $f.angle $f.uangle -padx 2 -pady 2 -sticky w
 
     # init
     IllustrateEllipseEditCB $var(id)
@@ -129,13 +138,70 @@ proc IllustrateEllipseApply {varname} {
 	set yc $var(yc)
 	set rr1 $var(rr1)
 	set rr2 $var(rr2)
+	set angle $var(angle)
 
 	$ds9(canvas) coords $var(id) \
-	    [expr $xc-$rr1] [expr $yc-$rr2] \
-	    [expr $xc+$rr1] [expr $yc+$rr2]
+	    [IllustrateBaseRotatedCoords $xc $yc $rr1 $rr2 $angle 72]
 
 	IllustrateBaseUpdateHandle $var(id)
     }
+}
+
+proc IllustrateEllipseRotate {id xx yy} {
+    global ds9
+    global iillustrate
+
+    foreach {xc yc rr1 rr2 angle} [IllustrateEllipseGeometry $id] {}
+    set dx [expr {$xx-$xc}]
+    set dy [expr {$yy-$yc}]
+    set aa [expr {atan2($dy,$dx)*180./acos(-1)}]
+
+    switch $iillustrate(handle) {
+	1 {set bx -$rr1; set by -$rr2}
+	2 {set bx $rr1; set by -$rr2}
+	3 {set bx $rr1; set by $rr2}
+	4 {set bx -$rr1; set by $rr2}
+    }
+    set bb [expr {atan2($by,$bx)*180./acos(-1)}]
+    set angle [expr {$aa-$bb}]
+
+    $ds9(canvas) coords $id \
+	[IllustrateBaseRotatedCoords $xc $yc $rr1 $rr2 $angle 72]
+}
+
+proc IllustrateEllipseGeometry {id} {
+    global ds9
+
+    set coords [$ds9(canvas) coords $id]
+    if {[llength $coords] == 4} {
+	foreach {x1 y1 x2 y2} $coords {}
+	set xc [expr {($x2-$x1)/2+$x1}]
+	set yc [expr {($y2-$y1)/2+$y1}]
+	set rr1 [expr {abs($x2-$x1)/2}]
+	set rr2 [expr {abs($y2-$y1)/2}]
+	return [list $xc $yc $rr1 $rr2 0]
+    }
+
+    set xc 0
+    set yc 0
+    set cnt 0
+    foreach {xx yy} $coords {
+	set xc [expr {$xc+$xx}]
+	set yc [expr {$yc+$yy}]
+	incr cnt
+    }
+    set xc [expr {$xc/$cnt}]
+    set yc [expr {$yc/$cnt}]
+
+    set x1 [lindex $coords 0]
+    set y1 [lindex $coords 1]
+    set q [expr {int($cnt/4)*2}]
+    set x2 [lindex $coords $q]
+    set y2 [lindex $coords [expr {$q+1}]]
+    set rr1 [expr {sqrt(($x1-$xc)*($x1-$xc)+($y1-$yc)*($y1-$yc))}]
+    set rr2 [expr {sqrt(($x2-$xc)*($x2-$xc)+($y2-$yc)*($y2-$yc))}]
+    set angle [expr {atan2($y1-$yc,$x1-$xc)*180./acos(-1)}]
+    return [list $xc $yc $rr1 $rr2 $angle]
 }
 
 # callbacks
@@ -153,10 +219,10 @@ proc IllustrateEllipseEditCB {id} {
 
     global ds9
 
-    foreach {x1 y1 x2 y2} [$ds9(canvas) coords $id] {}
-    set var(xc) [expr ($x2-$x1)/2+$x1]
-    set var(yc) [expr ($y2-$y1)/2+$y1]
-    set var(rr1) [expr ($x2-$x1)/2]
-    set var(rr2) [expr ($y2-$y1)/2]
+    foreach {xc yc rr1 rr2 angle} [IllustrateEllipseGeometry $id] {}
+    set var(xc) $xc
+    set var(yc) $yc
+    set var(rr1) $rr1
+    set var(rr2) $rr2
+    set var(angle) $angle
 }
-

--- a/ds9/library/illustrateellipse.tcl
+++ b/ds9/library/illustrateellipse.tcl
@@ -58,8 +58,13 @@ proc IllustrateEllipseList {id} {
     global ds9
 
     foreach {xc yc r1 r2 angle} [IllustrateEllipseGeometry $id] {}
-    
-    return "ellipse $xc $yc $r1 $r2 [IllustrateBaseAngleProps $id $angle]"
+    set rr [format "ellipse %s %s %s %s" \
+		[IllustrateBaseFormatNumber $xc] \
+		[IllustrateBaseFormatNumber $yc] \
+		[IllustrateBaseFormatNumber $r1] \
+		[IllustrateBaseFormatNumber $r2]]
+    append rr [IllustrateBaseAngleProps $id $angle]
+    return $rr
 }
 
 # Dialog
@@ -208,9 +213,9 @@ proc IllustrateEllipseEditCB {id} {
     global ds9
 
     foreach {xc yc rr1 rr2 angle} [IllustrateEllipseGeometry $id] {}
-    set var(xc) $xc
-    set var(yc) $yc
-    set var(rr1) $rr1
-    set var(rr2) $rr2
-    set var(angle) $angle
+    set var(xc) [IllustrateBaseFormatNumber $xc]
+    set var(yc) [IllustrateBaseFormatNumber $yc]
+    set var(rr1) [IllustrateBaseFormatNumber $rr1]
+    set var(rr2) [IllustrateBaseFormatNumber $rr2]
+    set var(angle) [IllustrateBaseFormatNumber $angle]
 }

--- a/ds9/library/illustrateellipse.tcl
+++ b/ds9/library/illustrateellipse.tcl
@@ -47,21 +47,9 @@ proc IllustrateEllipseDefault {id} {
 
 proc IllustrateEllipseEdit {id xx yy} {
     global ds9
-    global iillustrate
 
     foreach {xc yc rr1 rr2 angle} [IllustrateEllipseGeometry $id] {}
-    foreach {x1 y1 x2 y2} [$ds9(canvas) bbox $id] {}
-    switch $iillustrate(handle) {
-	1 {set x1 $xx; set y1 $yy}
-	2 {set x2 $xx; set y1 $yy}
-	3 {set x2 $xx; set y2 $yy}
-	4 {set x1 $xx; set y2 $yy}
-    }
-
-    set xc [expr {($x2-$x1)/2+$x1}]
-    set yc [expr {($y2-$y1)/2+$y1}]
-    set rr1 [expr {abs($x2-$x1)/2}]
-    set rr2 [expr {abs($y2-$y1)/2}]
+    foreach {rr1 rr2} [IllustrateBaseRotatedRadii $xc $yc $xx $yy $angle] {}
     $ds9(canvas) coords $id \
 	[IllustrateBaseRotatedCoords $xc $yc $rr1 $rr2 $angle 72]
 }

--- a/ds9/library/illustrateproc.tcl
+++ b/ds9/library/illustrateproc.tcl
@@ -168,10 +168,10 @@ proc IllustrateEditCB {id} {
 proc IllustrateRotate {id xx yy} {
     switch [IllustrateGetType $id] {
 	circle -
-	ellipse -
-	box -
 	polygon -
 	line {}
+	ellipse {IllustrateEllipseRotate $id $xx $yy}
+	box {IllustrateBoxRotate $id $xx $yy}
 	text {IllustrateTextRotate $id $xx $yy}
 	image {IllustrateImageEdit $id $xx $yy 1}
     }
@@ -180,10 +180,10 @@ proc IllustrateRotate {id xx yy} {
 proc IllustrateRotateCB {id} {
     switch [IllustrateGetType $id] {
 	circle -
-	ellipse -
-	box -
 	polygon -
 	line {}
+	ellipse {IllustrateEllipseEditCB $id}
+	box {IllustrateBoxEditCB $id}
 	text {IllustrateTextRotateCB $id}
 	image {IllustrateImageEditCB $id}
     }

--- a/ds9/parsers/illustratefileparser.tac
+++ b/ds9/parsers/illustratefileparser.tac
@@ -56,9 +56,9 @@ command : VERSION_ {puts "DS9 Illustrate File 1.0"}
 shape : CIRCLE_ bp numeric sp numeric sp numeric ep comment
  {IllustrateCircleCreate $3 $5 $7 $illustratefile::localColor $illustratefile::localFill $illustratefile::localWidth $illustratefile::localDash}
  | ELLIPSE_ bp numeric sp numeric sp numeric sp numeric ep comment
- {IllustrateEllipseCreate $3 $5 $7 $9 $illustratefile::localColor $illustratefile::localFill $illustratefile::localWidth $illustratefile::localDash}
+ {IllustrateEllipseCreate $3 $5 $7 $9 $illustratefile::localColor $illustratefile::localFill $illustratefile::localWidth $illustratefile::localDash $illustratefile::localAngle}
  | BOX_ bp numeric sp numeric sp numeric sp numeric ep comment
- {IllustrateBoxCreate $3 $5 $7 $9 $illustratefile::localColor $illustratefile::localFill $illustratefile::localWidth $illustratefile::localDash}
+ {IllustrateBoxCreate $3 $5 $7 $9 $illustratefile::localColor $illustratefile::localFill $illustratefile::localWidth $illustratefile::localDash $illustratefile::localAngle}
  | POLYGON_ bp coords ep comment
  {IllustratePolygonCreate $illustratefile::coords $illustratefile::localColor $illustratefile::localFill $illustratefile::localWidth $illustratefile::localDash}
  | LINE_ bp numeric sp numeric sp numeric sp numeric ep comment

--- a/ds9/parsers/illustratefileparser.tcl
+++ b/ds9/parsers/illustratefileparser.tcl
@@ -5638,8 +5638,8 @@ proc illustratefile::yyparse {} {
                     24 { puts "DS9 Illustrate File 1.0" }
                     26 { initLocal }
                     29 { IllustrateCircleCreate $3 $5 $7 $illustratefile::localColor $illustratefile::localFill $illustratefile::localWidth $illustratefile::localDash }
-                    30 { IllustrateEllipseCreate $3 $5 $7 $9 $illustratefile::localColor $illustratefile::localFill $illustratefile::localWidth $illustratefile::localDash }
-                    31 { IllustrateBoxCreate $3 $5 $7 $9 $illustratefile::localColor $illustratefile::localFill $illustratefile::localWidth $illustratefile::localDash }
+                    30 { IllustrateEllipseCreate $3 $5 $7 $9 $illustratefile::localColor $illustratefile::localFill $illustratefile::localWidth $illustratefile::localDash $illustratefile::localAngle }
+                    31 { IllustrateBoxCreate $3 $5 $7 $9 $illustratefile::localColor $illustratefile::localFill $illustratefile::localWidth $illustratefile::localDash $illustratefile::localAngle }
                     32 { IllustratePolygonCreate $illustratefile::coords $illustratefile::localColor $illustratefile::localFill $illustratefile::localWidth $illustratefile::localDash }
                     33 { IllustrateLineCreate $3 $5 $7 $9 $illustratefile::localColor $illustratefile::localWidth $illustratefile::localDash $illustratefile::localLine1 $illustratefile::localLine2 }
                     34 { IllustrateTextCreate $3 $5 $7 $illustratefile::localColor $illustratefile::localFont $illustratefile::localFontSize $illustratefile::localFontWeight $illustratefile::localFontSlant $illustratefile::localAngle $illustratefile::localJustify }


### PR DESCRIPTION
Illustrate mode ellipses and boxes can now be rotated.

Because these are rooted in X11 primitives which do not support rotation, under the hood they are drawn as polygons. 