### PR TITLE
VO: Update URL to ds9.si.edu

### DIFF
--- a/ds9/library/prefs.tcl
+++ b/ds9/library/prefs.tcl
@@ -461,6 +461,7 @@ proc FixPrefs {version} {
     # these old vars may exists in the wild
     # be sure to rm them
     FixPrefsVarOld
+    FixPrefsVO
 
     switch $version {
 	5.x {
@@ -620,6 +621,14 @@ proc FixPrefs {version} {
 	}
 	8.4 {
 	}
+    }
+}
+
+proc FixPrefsVO {} {
+    global pvo
+
+    if {[info exists pvo(server)] && $pvo(server) == [VOLegacyServer]} {
+	set pvo(server) [VODefaultServer]
     }
 }
 

--- a/ds9/library/vo.tcl
+++ b/ds9/library/vo.tcl
@@ -4,6 +4,14 @@
 
 package provide DS9 1.0
 
+proc VODefaultServer {} {
+    return {https://ds9.si.edu/chandraed/list.txt}
+}
+
+proc VOLegacyServer {} {
+    return {https://cxc.harvard.edu/chandraed/list.txt}
+}
+
 proc VODef {} {
     global ivo
     global pvo
@@ -19,7 +27,7 @@ proc VODef {} {
     set ivo(ka,id) {}
 
     # prefs only
-    set pvo(server) {https://cxc.harvard.edu/chandraed/list.txt}
+    set pvo(server) [VODefaultServer]
     set pvo(hv) 1
     # only support mime now (not xpa)
     set pvo(method) mime
@@ -240,7 +248,7 @@ proc VOApply {varname} {
     
     # next try
     set var(valid) 0
-    VOLoad $varname {https://cxc.harvard.edu/chandraed/list.txt}
+    VOLoad $varname [VODefaultServer]
     if {$var(valid)} {
 	VOKeepAlive 0
 	return


### PR DESCRIPTION
This updates the Virtual Observatory URL from cxc.harvard.edu to ds9.si.edu.

The old files belonged to Eric and the 2nd Rutgers server was offline. Not sure why it was moved to CXC server. Seems like it should belong to ds9. 
