### PR TITLE
Grid control panel

### DIFF
--- a/ds9/library/grid.tcl
+++ b/ds9/library/grid.tcl
@@ -101,7 +101,7 @@ proc GridDefault {} {
 
 proc UpdateGridCurrent {} {
     global current
-    
+
     if {$current(frame) != {}} {
 	UpdateGrid $current(frame)
     }
@@ -119,7 +119,7 @@ proc UpdateGrid {which} {
     } else {
 	$which grid delete
     }
-}	    
+}
 
 proc UpdateGridZoom {} {
     global grid
@@ -202,7 +202,7 @@ proc GridBuildOptions {which} {
 	    append opt " Format(2)=$ff,"
 	}
     }
-    
+
     # Ticks
     if {!$grid(tick)} {
 	append opt " MajTickLen=0,"
@@ -215,7 +215,7 @@ proc GridBuildOptions {which} {
 		    base -
 		    rgb {}
 		    3d {append opt " MinTick(3)=0,"}
-		}		    
+		}
 	    }
 	}
     }
@@ -251,7 +251,7 @@ proc GridBuildOptions {which} {
 		base -
 		rgb {append opt " TextLab=$grid(textlab),"}
 		3d {append opt " TextLab=0,"}
-	    }		    
+	    }
 	}
     }
     if {!$grid(textlab,def1)} {
@@ -337,7 +337,7 @@ proc GridBuildOptions {which} {
 		    set numy -.03
 		}
 		3d {}
-	    }		    
+	    }
 	}
 	publication {
 	    switch -- [$which get type] {
@@ -356,7 +356,7 @@ proc GridBuildOptions {which} {
 		    }
 		}
 		3d {}
-	    }		    
+	    }
 	}
     }
 
@@ -436,7 +436,7 @@ proc GridBuildOptions {which} {
 		base -
 		rgb {}
 		3d {append opt " Norm(1)=0, Norm(2)=0, Norm(3)=-1,"}
-	    }		    
+	    }
 	}
     }
 
@@ -575,7 +575,7 @@ proc GridDialog {} {
     set w $igrid(top)
     set mb $igrid(mb)
 
-    Toplevel $w $mb 6 [msgcat::mc {Coordinate Grid Control Panel}] \
+    Toplevel $w $mb 6 [msgcat::mc {Coordinate Grid Parameters}] \
 	GridDestroyDialog
 
     $mb add cascade -label [msgcat::mc {File}] -menu $mb.file
@@ -870,12 +870,12 @@ proc GridDialog {} {
 	-variable grid(title,def) -command GridApplyDialog
     ttk::label $f.label1 -text "[msgcat::mc {Axis}] 1"
     ttk::entry $f.title1 -textvariable grid(textlab,text1) \
-	-width 60 
+	-width 60
     ttk::checkbutton $f.default1 -text [msgcat::mc {Default}] \
 	-variable grid(textlab,def1) -command GridApplyDialog
     ttk::label $f.label2 -text "[msgcat::mc {Axis}] 2"
     ttk::entry $f.title2 -textvariable grid(textlab,text2) \
-	-width 60 
+	-width 60
     ttk::checkbutton $f.default2 -text [msgcat::mc {Default}] \
 	-variable grid(textlab,def2) -command GridApplyDialog
 
@@ -893,26 +893,26 @@ proc GridDialog {} {
 
     ttk::label $f.titlet -text [msgcat::mc {Title}]
     ttk::entry $f.spacet -textvariable grid(title,gap) \
-	-width 8 
+	-width 8
 
     ttk::label $f.title1 -text "[msgcat::mc {Axis}] 1"
-    ttk::entry $f.tspace1 -textvariable grid(textlab,gap1) -width 8 
-    ttk::entry $f.nspace1 -textvariable grid(numlab,gap1) -width 8 
-    ttk::entry $f.format1 -textvariable grid(format1) -width 8 
-    ttk::entry $f.gap1 -textvariable grid(grid,gap1) -width 8 
+    ttk::entry $f.tspace1 -textvariable grid(textlab,gap1) -width 8
+    ttk::entry $f.nspace1 -textvariable grid(numlab,gap1) -width 8
+    ttk::entry $f.format1 -textvariable grid(format1) -width 8
+    ttk::entry $f.gap1 -textvariable grid(grid,gap1) -width 8
     ttk::label $f.gapunit1 -textvariable grid(grid,gapunit1)
 
     ttk::label $f.title2 -text "[msgcat::mc {Axis}] 2"
-    ttk::entry $f.tspace2 -textvariable grid(textlab,gap2) -width 8 
-    ttk::entry $f.nspace2 -textvariable grid(numlab,gap2) -width 8 
-    ttk::entry $f.format2 -textvariable grid(format2) -width 8 
-    ttk::entry $f.gap2 -textvariable grid(grid,gap2) -width 8 
+    ttk::entry $f.tspace2 -textvariable grid(textlab,gap2) -width 8
+    ttk::entry $f.nspace2 -textvariable grid(numlab,gap2) -width 8
+    ttk::entry $f.format2 -textvariable grid(format2) -width 8
+    ttk::entry $f.gap2 -textvariable grid(grid,gap2) -width 8
     ttk::label $f.gapunit2 -textvariable grid(grid,gapunit2)
 
     ttk::label $f.title3 -text "[msgcat::mc {Axis}] 3"
-    ttk::entry $f.nspace3 -textvariable grid(numlab,gap3) -width 8 
-    ttk::entry $f.format3 -textvariable grid(format3) -width 8 
-    ttk::entry $f.gap3 -textvariable grid(grid,gap3) -width 8 
+    ttk::entry $f.nspace3 -textvariable grid(numlab,gap3) -width 8
+    ttk::entry $f.format3 -textvariable grid(format3) -width 8
+    ttk::entry $f.gap3 -textvariable grid(grid,gap3) -width 8
     ttk::label $f.gapunit3 -textvariable grid(grid,gapunit3)
 
     grid x $f.lspace $f.ngap $f.lformat $f.lgap -padx 2 -pady 2 -sticky w
@@ -1182,7 +1182,7 @@ proc GridCreateColorMenuButton {which color} {
 
 proc GridLoadDialog {} {
     global igrid
-    
+
     set fn [OpenFileDialog gridfbox $igrid(top)]
     GridLoad $fn
 }

--- a/ds9/library/grid.tcl
+++ b/ds9/library/grid.tcl
@@ -575,7 +575,7 @@ proc GridDialog {} {
     set w $igrid(top)
     set mb $igrid(mb)
 
-    Toplevel $w $mb 6 [msgcat::mc {Coordinate Grid Parameters}] \
+    Toplevel $w $mb 6 [msgcat::mc {Coordinate Grid Control Panel}] \
 	GridDestroyDialog
 
     $mb add cascade -label [msgcat::mc {File}] -menu $mb.file
@@ -740,6 +740,127 @@ proc GridDialog {} {
     ColorMenu $mb.border.color grid border,color GridApplyDialog
     GridCreateLineMenu $mb.border.line border,width border,style
 
+    # General
+    set f [ttk::labelframe $w.general -text [msgcat::mc {Coordinate Grid}] -padding 2]
+    ttk::checkbutton $f.view -text [msgcat::mc {Show}] \
+	-variable grid(view) -command UpdateGridCurrent
+
+    ttk::label $f.ttype -text [msgcat::mc {Type}]
+    ttk::radiobutton $f.analysis -text [msgcat::mc {Analysis}] \
+	-variable grid(type) -value analysis -command GridApplyDialog
+    ttk::radiobutton $f.publication -text [msgcat::mc {Publication}] \
+	-variable grid(type) -value publication -command GridApplyDialog
+
+    ttk::label $f.tcoord -text [msgcat::mc {Coordinate}]
+    CoordMenuButton $f.coord grid system 1 sky skyformat GridApplyDialog
+
+    grid $f.view -padx 2 -pady 2 -sticky w
+    grid $f.ttype $f.analysis $f.publication -padx 2 -pady 2 -sticky w
+    grid $f.tcoord $f.coord -padx 2 -pady 2 -sticky w
+
+    # Appearance
+    set f [ttk::labelframe $w.appearance -text [msgcat::mc {Appearance}] -padding 2]
+    ttk::label $f.tcomponent -text [msgcat::mc {Component}]
+    ttk::label $f.tshow -text [msgcat::mc {Show}]
+    ttk::label $f.tcolor -text [msgcat::mc {Color}]
+    ttk::label $f.tline -text [msgcat::mc {Line}]
+
+    ttk::label $f.tgrid -text [msgcat::mc {Grid}]
+    ttk::checkbutton $f.gridshow -variable grid(grid) -command GridApplyDialog
+    GridCreateColorMenuButton $f.gridcolor grid,color
+    GridCreateLineMenuButton $f.gridline grid,width grid,style
+
+    ttk::label $f.taxes -text [msgcat::mc {Axes}]
+    ttk::checkbutton $f.axesshow -variable grid(axes) -command GridApplyDialog
+    GridCreateColorMenuButton $f.axescolor axes,color
+    GridCreateLineMenuButton $f.axesline axes,width axes,style
+
+    ttk::label $f.ttick -text [msgcat::mc {Tickmarks}]
+    ttk::checkbutton $f.tickshow -variable grid(tick) -command GridApplyDialog
+    GridCreateColorMenuButton $f.tickcolor tick,color
+    GridCreateLineMenuButton $f.tickline tick,width tick,style
+
+    ttk::label $f.tborder -text [msgcat::mc {Border}]
+    ttk::checkbutton $f.bordershow -variable grid(border) -command GridApplyDialog
+    GridCreateColorMenuButton $f.bordercolor border,color
+    GridCreateLineMenuButton $f.borderline border,width border,style
+
+    grid $f.tcomponent $f.tshow $f.tcolor $f.tline \
+	-padx 2 -pady 2 -sticky w
+    grid $f.tgrid $f.gridshow $f.gridcolor $f.gridline \
+	-padx 2 -pady 2 -sticky w
+    grid $f.taxes $f.axesshow $f.axescolor $f.axesline \
+	-padx 2 -pady 2 -sticky w
+    grid $f.ttick $f.tickshow $f.tickcolor $f.tickline \
+	-padx 2 -pady 2 -sticky w
+    grid $f.tborder $f.bordershow $f.bordercolor $f.borderline \
+	-padx 2 -pady 2 -sticky w
+
+    # Axes
+    set f [ttk::labelframe $w.axes -text [msgcat::mc {Axes}] -padding 2]
+    ttk::label $f.taxes -text [msgcat::mc {Axes}]
+    ttk::radiobutton $f.axesin -text [msgcat::mc {Interior}] \
+	-variable grid(axes,type) -value interior -command GridApplyDialog
+    ttk::radiobutton $f.axesout -text [msgcat::mc {Exterior}] \
+	-variable grid(axes,type) -value exterior -command GridApplyDialog
+
+    ttk::label $f.tnumlab -text [msgcat::mc {Numerics}]
+    ttk::checkbutton $f.numlabshow -text [msgcat::mc {Show}] \
+	-variable grid(numlab) -command GridApplyDialog
+    ttk::radiobutton $f.numlabin -text [msgcat::mc {Interior}] \
+	-variable grid(numlab,type) -value interior -command GridApplyDialog
+    ttk::radiobutton $f.numlabout -text [msgcat::mc {Exterior}] \
+	-variable grid(numlab,type) -value exterior -command GridApplyDialog
+    ttk::checkbutton $f.numlabvert -text [msgcat::mc {Vertical Text}] \
+	-variable grid(numlab,vertical) -command GridApplyDialog
+
+    ttk::label $f.torigin -text [msgcat::mc {Origin}]
+    ttk::menubutton $f.origin -textvariable grid(axes,origin) \
+	-menu $f.origin.menu
+    $mb.axes.origin clone $f.origin.menu
+
+    grid $f.taxes $f.axesin $f.axesout -padx 2 -pady 2 -sticky w
+    grid $f.tnumlab $f.numlabshow $f.numlabin $f.numlabout \
+	$f.numlabvert -padx 2 -pady 2 -sticky w
+    grid $f.torigin $f.origin -padx 2 -pady 2 -sticky w
+
+    # Text
+    set f [ttk::labelframe $w.text -text [msgcat::mc {Text}] -padding 2]
+    ttk::label $f.tcomponent -text [msgcat::mc {Component}]
+    ttk::label $f.tshow -text [msgcat::mc {Show}]
+    ttk::label $f.tcolor -text [msgcat::mc {Color}]
+    ttk::label $f.tfont -text [msgcat::mc {Font}]
+
+    ttk::label $f.tnumlab -text [msgcat::mc {Numerics}]
+    ttk::checkbutton $f.numlabshow -variable grid(numlab) \
+	-command GridApplyDialog
+    GridCreateColorMenuButton $f.numlabcolor numlab,color
+    FontMenuButton $f.numlabfont grid numlab,font numlab,size \
+	numlab,weight numlab,slant GridApplyDialog
+
+    ttk::label $f.ttextlab -text [msgcat::mc {Labels}]
+    ttk::checkbutton $f.textlabshow -variable grid(textlab) \
+	-command GridApplyDialog
+    GridCreateColorMenuButton $f.textlabcolor textlab,color
+    FontMenuButton $f.textlabfont grid textlab,font textlab,size \
+	textlab,weight textlab,slant GridApplyDialog
+
+    ttk::label $f.ttitle -text [msgcat::mc {Title}]
+    ttk::checkbutton $f.titleshow -variable grid(title) \
+	-command GridApplyDialog
+    GridCreateColorMenuButton $f.titlecolor title,color
+    FontMenuButton $f.titlefont grid title,font title,size \
+	title,weight title,slant GridApplyDialog
+
+    grid $f.tcomponent $f.tshow $f.tcolor $f.tfont \
+	-padx 2 -pady 2 -sticky w
+    grid $f.tnumlab $f.numlabshow $f.numlabcolor $f.numlabfont \
+	-padx 2 -pady 2 -sticky w
+    grid $f.ttextlab $f.textlabshow $f.textlabcolor $f.textlabfont \
+	-padx 2 -pady 2 -sticky w
+    grid $f.ttitle $f.titleshow $f.titlecolor $f.titlefont \
+	-padx 2 -pady 2 -sticky w
+
     # Labels
     set f [ttk::labelframe $w.label -text [msgcat::mc {Labels}] -padding 2]
     ttk::label $f.label -text [msgcat::mc {Title}]
@@ -811,12 +932,17 @@ proc GridDialog {} {
 	-padx 2 -pady 4
 
     # Fini
-    grid $w.label -sticky news
-    grid $w.param -sticky news
-    grid $w.buttons -sticky ew
+    grid $w.general $w.axes -sticky news
+    grid $w.appearance $w.text -sticky news
+    grid $w.label - -sticky news
+    grid $w.param - -sticky news
+    grid $w.buttons - -sticky ew
     grid rowconfigure $w 0 -weight 1
     grid rowconfigure $w 1 -weight 1
+    grid rowconfigure $w 2 -weight 1
+    grid rowconfigure $w 3 -weight 1
     grid columnconfigure $w 0 -weight 1
+    grid columnconfigure $w 1 -weight 1
 
     bind $w <Return> GridApplyDialog
 
@@ -944,6 +1070,24 @@ proc UpdateGridDialog {} {
 		    $g.tspace1 configure -state normal
 		    $g.tspace2 configure -state normal
 
+		    set a $igrid(top).axes
+		    GridSetWidgetState normal \
+			$a.axesin $a.axesout $a.numlabshow $a.numlabin \
+			$a.numlabout $a.numlabvert
+		    GridSetWidgetState disabled $a.origin
+
+		    set t $igrid(top).text
+		    GridSetWidgetState normal \
+			$t.numlabshow $t.numlabcolor $t.numlabfont \
+			$t.textlabshow $t.textlabcolor $t.textlabfont \
+			$t.titleshow $t.titlecolor $t.titlefont
+
+		    set h $igrid(top).label
+		    GridSetWidgetState normal \
+			$h.label $h.title $h.default \
+			$h.label1 $h.title1 $h.default1 \
+			$h.label2 $h.title2 $h.default2
+
 		    grid forget $g.title3 $g.nspace3 $g.format3 $g.gap3 \
 			$g.gapunit3
 		}
@@ -973,6 +1117,25 @@ proc UpdateGridDialog {} {
 		    $g.tspace1 configure -state disabled
 		    $g.tspace2 configure -state disabled
 
+		    set a $igrid(top).axes
+		    GridSetWidgetState normal \
+			$a.axesin $a.axesout $a.numlabshow $a.origin
+		    GridSetWidgetState disabled \
+			$a.numlabin $a.numlabout $a.numlabvert
+
+		    set t $igrid(top).text
+		    GridSetWidgetState normal \
+			$t.numlabshow $t.numlabcolor $t.numlabfont
+		    GridSetWidgetState disabled \
+			$t.textlabshow $t.textlabcolor $t.textlabfont \
+			$t.titleshow $t.titlecolor $t.titlefont
+
+		    set h $igrid(top).label
+		    GridSetWidgetState disabled \
+			$h.label $h.title $h.default \
+			$h.label1 $h.title1 $h.default1 \
+			$h.label2 $h.title2 $h.default2
+
 		    grid $g.title3 x $g.nspace3 $g.format3 $g.gap3 $g.gapunit3 \
 			-padx 2 -pady 2 -sticky w
 		}
@@ -981,9 +1144,22 @@ proc UpdateGridDialog {} {
 	    set grid(frame) $current(frame)
 	    if {[$current(frame) has fits]} {
 		CoordMenuEnable $igrid(mb).coord grid system sky skyformat
+		CoordMenuEnable $igrid(top).general.coord.menu \
+		    grid system sky skyformat
 	    } else {
 		CoordMenuReset $igrid(mb).coord grid system sky skyformat
+		CoordMenuReset $igrid(top).general.coord.menu \
+		    grid system sky skyformat
 	    }
+	    CoordMenuButtonCmd grid system sky {}
+	}
+    }
+}
+
+proc GridSetWidgetState {state args} {
+    foreach w $args {
+	if {[winfo exists $w]} {
+	    $w configure -state $state
 	}
     }
 }
@@ -993,6 +1169,15 @@ proc GridCreateLineMenu {which width dash} {
     global grid
 
     WidthDashMenu $which grid $width $dash GridApplyDialog GridApplyDialog
+}
+
+proc GridCreateLineMenuButton {which width dash} {
+    ttk::menubutton $which -textvariable grid($width) -menu $which.menu
+    GridCreateLineMenu $which.menu $width $dash
+}
+
+proc GridCreateColorMenuButton {which color} {
+    ColorMenuButton $which grid $color GridApplyDialog
 }
 
 proc GridLoadDialog {} {

--- a/ds9/library/grid.tcl
+++ b/ds9/library/grid.tcl
@@ -624,7 +624,7 @@ proc GridDialog {} {
     $mb.type add radiobutton -label [msgcat::mc {Exterior Numerics}] \
 	-variable grid(numlab,type) -value exterior -command GridApplyDialog
     $mb.type add separator
-    $mb.type add checkbutton -label [msgcat::mc {Vertical Text}] \
+    $mb.type add checkbutton -label [msgcat::mc {Horizontal Text}] \
 	-variable grid(numlab,vertical) -command GridApplyDialog
 
     # Coordinate
@@ -811,7 +811,7 @@ proc GridDialog {} {
 	-variable grid(numlab,type) -value interior -command GridApplyDialog
     ttk::radiobutton $f.numlabout -text [msgcat::mc {Exterior}] \
 	-variable grid(numlab,type) -value exterior -command GridApplyDialog
-    ttk::checkbutton $f.numlabvert -text [msgcat::mc {Vertical Text}] \
+    ttk::checkbutton $f.numlabvert -text [msgcat::mc {Horizontal Text}] \
 	-variable grid(numlab,vertical) -command GridApplyDialog
 
     ttk::label $f.torigin -text [msgcat::mc {Origin}]
@@ -1050,7 +1050,7 @@ proc UpdateGridDialog {} {
 			-state normal
 		    $mb.type entryconfig [msgcat::mc {Exterior Numerics}] \
 			-state normal
-		    $mb.type entryconfig [msgcat::mc {Vertical Text}] \
+		    $mb.type entryconfig [msgcat::mc {Horizontal Text}] \
 			-state normal
 		    $mb.axes entryconfig [msgcat::mc {Origin}] \
 			-state disable
@@ -1098,7 +1098,7 @@ proc UpdateGridDialog {} {
 			-state disabled
 		    $mb.type entryconfig [msgcat::mc {Exterior Numerics}] \
 			-state disabled
-		    $mb.type entryconfig [msgcat::mc {Vertical Text}] \
+		    $mb.type entryconfig [msgcat::mc {Horizontal Text}] \
 			-state disabled
 		    $mb.axes entryconfig [msgcat::mc {Origin}] -state normal
 

--- a/ds9/library/manalysis.tcl
+++ b/ds9/library/manalysis.tcl
@@ -31,7 +31,7 @@ proc AnalysisMainMenu {} {
     $ds9(mb).analysis add checkbutton -label [msgcat::mc {Coordinate Grid}] \
 	-variable grid(view) -command UpdateGridCurrent
     $ds9(mb).analysis add command \
-	-label [msgcat::mc {Coordinate Grid Control Panel}] \
+	-label [msgcat::mc {Coordinate Grid Parameters}] \
 	-command GridDialog
     $ds9(mb).analysis add separator
     $ds9(mb).analysis add cascade -label [msgcat::mc {Block}] \

--- a/ds9/library/manalysis.tcl
+++ b/ds9/library/manalysis.tcl
@@ -31,7 +31,7 @@ proc AnalysisMainMenu {} {
     $ds9(mb).analysis add checkbutton -label [msgcat::mc {Coordinate Grid}] \
 	-variable grid(view) -command UpdateGridCurrent
     $ds9(mb).analysis add command \
-	-label [msgcat::mc {Coordinate Grid Parameters}] \
+	-label [msgcat::mc {Coordinate Grid Control Panel}] \
 	-command GridDialog
     $ds9(mb).analysis add separator
     $ds9(mb).analysis add cascade -label [msgcat::mc {Block}] \

--- a/ds9/msgs/cs.msg
+++ b/ds9/msgs/cs.msg
@@ -1033,7 +1033,7 @@
 ::msgcat::mcset cs {Vector} 
 ::msgcat::mcset cs {Vertical Graph} [encoding convertfrom iso8859-2 {Vertikální graf}]
 ::msgcat::mcset cs {Vertical Layout} [encoding convertfrom iso8859-2 {Vertikální rozlo¾ení}]
-::msgcat::mcset cs {Vertical Text} 
+::msgcat::mcset cs {Horizontal Text}
 ::msgcat::mcset cs {Vertical} 
 ::msgcat::mcset cs {View} [encoding convertfrom iso8859-2 {Zobrazit}]
 ::msgcat::mcset cs {Virtual Observatory} [encoding convertfrom iso8859-2 {Virtuální Observatoø}]

--- a/ds9/msgs/da.msg
+++ b/ds9/msgs/da.msg
@@ -1033,7 +1033,7 @@
 ::msgcat::mcset da {Vector} {Vektor}
 ::msgcat::mcset da {Vertical Graph} {Lodret graf}
 ::msgcat::mcset da {Vertical Layout} {Lodret layoyt}
-::msgcat::mcset da {Vertical Text} {Lodret tekst}
+::msgcat::mcset da {Horizontal Text} {Vandret tekst}
 ::msgcat::mcset da {Vertical} 
 ::msgcat::mcset da {View} {Vis}
 ::msgcat::mcset da {Virtual Observatory} {Virtuelt Observatorium}

--- a/ds9/msgs/de.msg
+++ b/ds9/msgs/de.msg
@@ -1033,7 +1033,7 @@
 ::msgcat::mcset de {Vector} {Vektor}
 ::msgcat::mcset de {Vertical Graph} {Vertikaldarstellung}
 ::msgcat::mcset de {Vertical Layout} {Vertikales layout}
-::msgcat::mcset de {Vertical Text} {Vertikaler text}
+::msgcat::mcset de {Horizontal Text} {Horizontaler Text}
 ::msgcat::mcset de {Vertical} 
 ::msgcat::mcset de {View} {Ansicht}
 ::msgcat::mcset de {Virtual Observatory} 

--- a/ds9/msgs/es.msg
+++ b/ds9/msgs/es.msg
@@ -1033,7 +1033,7 @@
 ::msgcat::mcset es {Vector} 
 ::msgcat::mcset es {Vertical Graph} [encoding convertfrom iso8859-1 {Gráfica vertical}]
 ::msgcat::mcset es {Vertical Layout} [encoding convertfrom iso8859-1 {Distribución vertical}]
-::msgcat::mcset es {Vertical Text} {Texto vertical} 
+::msgcat::mcset es {Horizontal Text} {Texto horizontal}
 ::msgcat::mcset es {Vertical} 
 ::msgcat::mcset es {View} {Ver}
 ::msgcat::mcset es {Virtual Observatory} {Observatorio Virtual}

--- a/ds9/msgs/fr.msg
+++ b/ds9/msgs/fr.msg
@@ -1033,7 +1033,7 @@
 ::msgcat::mcset fr {Vector} 
 ::msgcat::mcset fr {Vertical Graph} 
 ::msgcat::mcset fr {Vertical Layout} 
-::msgcat::mcset fr {Vertical Text} 
+::msgcat::mcset fr {Horizontal Text}
 ::msgcat::mcset fr {Vertical} 
 ::msgcat::mcset fr {View} {Affichage}
 ::msgcat::mcset fr {Virtual Observatory} 

--- a/ds9/msgs/ja.msg
+++ b/ds9/msgs/ja.msg
@@ -1033,7 +1033,7 @@
 ::msgcat::mcset ja {Vector} [encoding convertfrom euc-jp "\xa5\xd9\xa5\xaf\xa5\xc8\xa5\xeb"]
 ::msgcat::mcset ja {Vertical Graph} [encoding convertfrom euc-jp "\xbd\xc4\xc3\xc7\xcc\xcc"]
 ::msgcat::mcset ja {Vertical Layout} [encoding convertfrom euc-jp "\xb2\xe8\xcc\xcc\xa4\xce\xba\xb8\xa4\xcb\xc7\xdb\xc3\xd6"]
-::msgcat::mcset ja {Vertical Text} 
+::msgcat::mcset ja {Horizontal Text}
 ::msgcat::mcset ja {Vertical} 
 ::msgcat::mcset ja {View} [encoding convertfrom euc-jp "\xc9\xbd\xbc\xa8"]
 ::msgcat::mcset ja {Virtual Observatory} [encoding convertfrom euc-jp "\xb2\xbe\xc1\xdb\xc5\xb7\xca\xb8\xc2\xe6"]

--- a/ds9/msgs/pt.msg
+++ b/ds9/msgs/pt.msg
@@ -1033,7 +1033,7 @@
 ::msgcat::mcset pt {Vector} {Vetor}
 ::msgcat::mcset pt {Vertical Graph} [encoding convertfrom iso8859-1 {Gráfico Vertical}]
 ::msgcat::mcset pt {Vertical Layout} {Layout Vertical}
-::msgcat::mcset pt {Vertical Text} {Texto Vertical}
+::msgcat::mcset pt {Horizontal Text} {Texto Horizontal}
 ::msgcat::mcset pt {Vertical} 
 ::msgcat::mcset pt {View} {Visualizar}
 ::msgcat::mcset pt {Virtual Observatory} [encoding convertfrom iso8859-1 {Observatório Virtual}]

--- a/ds9/msgs/zh.msg
+++ b/ds9/msgs/zh.msg
@@ -1033,7 +1033,7 @@
 ::msgcat::mcset zh {Vector} [encoding convertfrom big5 "\xA6\x56 \xB6\x71"]
 ::msgcat::mcset zh {Vertical Graph} 
 ::msgcat::mcset zh {Vertical Layout} 
-::msgcat::mcset zh {Vertical Text} 
+::msgcat::mcset zh {Horizontal Text}
 ::msgcat::mcset zh {Vertical} [encoding convertfrom big5 "\xAB\xAB \xAA\xBD"]
 ::msgcat::mcset zh {View} [encoding convertfrom big5 "\xC0\xCB \xB5\xF8"]
 ::msgcat::mcset zh {Virtual Observatory} 


### PR DESCRIPTION
This PR updates the Grid Parameters widget to look more like the Plot Control Panel where all the grid properties are exposed in a single UI rather than being accessible via a cascade of menus.  (The menu cascade is still available.) 

There is one "functional" change.  The "Vertical Text" has been renamed "Horizontal Text".  When the old "Vertical" checkbox is checked, the Y-axis (Dec usually) is rendered as horizontal text. Unchecking the box would render vertical text.  To preserve the current behavior in e.g.. backup files and grid save files, we just rename the element in the GUI to be "Horizontal Text". 
