### PR TITLE
TKSAO: add checks for empty WCS before trying to write

### DIFF
--- a/tksao/frame/fitsimage.C
+++ b/tksao/frame/fitsimage.C
@@ -3608,6 +3608,9 @@ void ast2FitsSink(const char* line)
 
 void FitsImage::ast2Fits()
 {
+  if (!ast_)
+    return;
+
   // we may have an error, just reset
   astClearStatus;
   astBegin;

--- a/tksao/frame/wcsast.C
+++ b/tksao/frame/wcsast.C
@@ -6,6 +6,9 @@
 
 int wcsSystem(AstFrameSet* ast, Coord::CoordSystem sys)
 {
+  if (!ast)
+    return 0;
+
   int nn = astGetI(ast,"nframe");
   char cc = ' ';
   int ww = sys-Coord::WCS;


### PR DESCRIPTION
There was an AST generated error (warning) reported by @DougBurke when trying to save WCS from a file w/o any WCS. This prevents a NUL pointer from being passed to AST, so no warning. 