### PR TITLE
REGION: 3d cutout

### DIFF
--- a/ds9/library/colorbar.tcl
+++ b/ds9/library/colorbar.tcl
@@ -911,6 +911,7 @@ proc ResetColormap {} {
     set colorbar(invert) [$current(colorbar) get invert]
     if {$current(frame) != {} } {
 	EvalLockCurrent lock,colorbar [list $current(frame) colormap [$current(colorbar) get colormap]]
+	MarkerAnalysisPlot3dUpdateColorbar $current(frame)
     }
 
     LockColorCurrent
@@ -1387,6 +1388,7 @@ proc ChangeColormapName {name} {
     set colorbar(invert) [$current(colorbar) get invert]
     if {$current(frame) != {} } {
 	$current(frame) colormap [$current(colorbar) get colormap]
+	MarkerAnalysisPlot3dUpdateColorbar $current(frame)
     }
 
     LockColorCurrent
@@ -1445,6 +1447,7 @@ proc InvertColorbar {} {
 
     if {$current(frame) != {} } {
 	$current(frame) colormap [$current(colorbar) get colormap]
+	MarkerAnalysisPlot3dUpdateColorbar $current(frame)
     }
 
     LockColorCurrent
@@ -1905,6 +1908,7 @@ proc ApplyColormap {} {
     EvalLockColorbarCurrent [list $current(colorbar) adjust $dcolorbar(contrast) $dcolorbar(bias)]
     if {$current(frame) != {}} {
 	EvalLockCurrent lock,colorbar [list $current(frame) colormap [$current(colorbar) get colormap]]
+	MarkerAnalysisPlot3dUpdateColorbar $current(frame)
 	LockColorCurrent
     }
 }
@@ -1931,6 +1935,7 @@ proc AdjustColormap {} {
 	EvalLockColorbarCurrent [list $current(colorbar) adjust $dcolorbar(contrast) $dcolorbar(bias)]
 	if {$current(frame) != {}} {
 	    EvalLockCurrent lock,colorbar [list $current(frame) colormap motion [$current(colorbar) get colormap]]
+	    MarkerAnalysisPlot3dUpdateColorbar $current(frame)
 	}
     }
 }

--- a/ds9/library/colorbar.tcl
+++ b/ds9/library/colorbar.tcl
@@ -1358,6 +1358,7 @@ proc ColorbarMotion3 {frame xx yy} {
 
     EvalLockColorbar $frame [list $cb adjust $contrast $bias]
     $frame colormap motion [$cb get colormap]
+    MarkerAnalysisPlot3dUpdateColorbar $frame
     UpdateColorDialog
 }
 
@@ -1374,6 +1375,7 @@ proc ColorbarRelease3 {frame x y} {
 
     $frame colormap end
 
+    MarkerAnalysisPlot3dUpdateColorbar $frame
     LockColor $frame
     UpdateColorDialog
 }
@@ -2283,6 +2285,7 @@ proc CmapValueCmd {c b} {
 	EvalLockCurrent lock,colorbar [list $current(frame) colormap begin]
 	EvalLockCurrent lock,colorbar [list $current(frame) colormap motion [$current(colorbar) get colormap]]
 	EvalLockCurrent lock,colorbar [list $current(frame) colormap end]
+	MarkerAnalysisPlot3dUpdateColorbar $current(frame)
     }
     LockColorCurrent
     UpdateColorDialog

--- a/ds9/library/frame.tcl
+++ b/ds9/library/frame.tcl
@@ -6,6 +6,15 @@ package provide DS9 1.0
 
 # Public Procedures
 
+proc FrameExists {which} {
+    global ds9
+
+    return [expr {$which != {} &&
+		  [info exists ds9(frames)] &&
+		  [lsearch -exact $ds9(frames) $which] >= 0 &&
+		  [llength [info commands $which]]}]
+}
+
 proc CreateFrame {} {
     CreateNamedFrame base
 }
@@ -133,7 +142,7 @@ proc CreateNameNumberFrame {which type} {
 	}
     }
     GraphsCreate $which
-    
+
     $which configure -x 0 -y 0 \
 	-anchor nw \
 	-tag $which \
@@ -169,7 +178,7 @@ proc CreateNameNumberFrame {which type} {
 	$pds9(prec,len,linear) $pds9(prec,len,deg) \
 	$pds9(prec,len,arcmin) $pds9(prec,len,arcsec) \
 	$pds9(prec,angle)
-    
+
     $which bg color $pds9(bg)
     $which bg color $pds9(bg,use)
     $which nan color $pds9(nan)
@@ -225,9 +234,9 @@ proc CreateNameNumberFrame {which type} {
 	    $which bin buffer size $bin(buffersize)
 
 	    $which block to $block(factor)
-	    
+
 	    $which cube axes $cube(axes)
-	    
+
 	    if {$smooth(view)} {
 		$which smooth $smooth(function) \
 		    $smooth(radius) $smooth(radius,minor) \
@@ -341,7 +350,7 @@ proc CreateNameNumberFrame {which type} {
 
     # enable events
     BindEventsFrame $which
-    
+
     switch -- $current(mode) {
 	crosshair {$which crosshair on}
     }
@@ -387,7 +396,7 @@ proc DeleteAllFrames {} {
     global ds9
 
     foreach ff $ds9(frames) {
-	DeleteFrame $ff
+	catch {DeleteFrame $ff}
     }
 
     set ds9(seq) 1
@@ -415,9 +424,15 @@ proc DeleteFrame {which} {
     global contour
     global marker
 
+    if {$which == {}} {
+	return
+    }
+
     # clear any loaded images
-    ClearFrame $which
+    if {[llength [info commands $which]]} {
+	ClearFrame $which
     BookmarksDeleteFrame $which
+    }
 
     # contour copy
     if {$contour(copy) == $which} {
@@ -427,16 +442,16 @@ proc DeleteFrame {which} {
     if {$marker(copy) == $which} {
 	set marker(copy) {}
     }
-    
+
     # delete canvas colorbar
-    $ds9(canvas) delete ${which}cb
+    catch {$ds9(canvas) delete ${which}cb}
     ColorbarFrameDelete $which
 
     # delete canvas graphs
-    GraphsDelete $which
+    catch {GraphsDelete $which}
 
     # delete canvas widget
-    $ds9(canvas) delete $which
+    catch {$ds9(canvas) delete $which}
 
     # reset current(frame) if needed
     if {$current(frame) == $which} {
@@ -452,12 +467,14 @@ proc DeleteFrame {which} {
     set ii [lsearch $ds9(active) $which]
     if {$ii>0} {
 	set ds9(active) [lreplace $ds9(active) $ii $ii]
-	unset active($which)
+	catch {unset active($which)}
     }
 
     # delete it from the frame list
     set ii [lsearch $ds9(frames) $which]
-    set ds9(frames) [lreplace $ds9(frames) $ii $ii]
+    if {$ii>=0} {
+	set ds9(frames) [lreplace $ds9(frames) $ii $ii]
+    }
 }
 
 proc UpdateCurrentFrame {} {
@@ -526,7 +543,7 @@ proc BindEventsFrame {which} {
 		[list Motion2Frame $which %x %y]
 	    $ds9(canvas) bind $which <ButtonRelease-2> \
 		[list Release2Frame $which %x %y]
-	} 
+	}
 	aqua {
 	    # swap button-2 and button-3 on the mighty mouse
 	    $ds9(canvas) bind $which <Button-3> \
@@ -547,7 +564,7 @@ proc BindEventsFrame {which} {
 		[list Release2Frame $which %x %y]
 
 	    # x11 command key emulation
-	    # we need this to eat the Button-1 events 
+	    # we need this to eat the Button-1 events
 	    # so it passes to the canvas
 	    $ds9(canvas) bind $which <Command-Button-1> {set foo bar}
 	    $ds9(canvas) bind $which <Command-B1-Motion> {set foo bar}
@@ -631,7 +648,7 @@ proc UnBindEventsFrame {which} {
 	    $ds9(canvas) bind $which <Shift-Button-2> {}
 	    $ds9(canvas) bind $which <B2-Motion> {}
 	    $ds9(canvas) bind $which <ButtonRelease-2> {}
-	} 
+	}
 	aqua {
 	    $ds9(canvas) bind $which <Command-Button-1> {}
 	    $ds9(canvas) bind $which <Command-B1-Motion> {}
@@ -692,7 +709,7 @@ proc EnterFrame {which x y} {
     }
 
     # check to see if this event was generated while processing other events
-    if {$ds9(b1) || $ds9(sb1) || $ds9(cb1) || 
+    if {$ds9(b1) || $ds9(sb1) || $ds9(cb1) ||
 	$ds9(csb1) || $ds9(b2) || $ds9(b3)} {
 	return
     }
@@ -750,7 +767,7 @@ proc LeaveFrame {which} {
     }
 
     # check to see if this event was generated while processing other events
-    if {$ds9(b1) || $ds9(sb1) || $ds9(cb1) || 
+    if {$ds9(b1) || $ds9(sb1) || $ds9(cb1) ||
 	$ds9(csb1) || $ds9(b2) || $ds9(b3)} {
 	return
     }
@@ -871,7 +888,7 @@ proc Button1Frame {which x y} {
 	none {
 	    if {$which == $current(frame)} {
 	    } else {
-		# we need this cause MarkerMotion maybe called, 
+		# we need this cause MarkerMotion maybe called,
 		# and we don't want it
 		set imarker(motion) none
 		set imarker(handle) -1
@@ -884,7 +901,7 @@ proc Button1Frame {which x y} {
 	    if {$which == $current(frame)} {
 		MarkerButton $which $x $y
 	    } else {
-		# we need this cause MarkerMotion maybe called, 
+		# we need this cause MarkerMotion maybe called,
 		# and we don't want it
 		set imarker(motion) none
 		set imarker(handle) -1
@@ -919,7 +936,7 @@ proc Button1Frame {which x y} {
 	    if {$which == $current(frame)} {
 		CATButton $which $x $y
 	    } else {
-		# we need this cause MarkerMotion maybe called, 
+		# we need this cause MarkerMotion maybe called,
 		# and we don't want it
 		set imarker(motion) none
 		set imarker(handle) -1
@@ -931,8 +948,8 @@ proc Button1Frame {which x y} {
             if {$which == $current(frame)} {
                 FPButton $which $x $y
             } else {
-                # we need this cause MarkerMotion maybe called,                 
-                # and we don't want it                                          
+                # we need this cause MarkerMotion maybe called,
+                # and we don't want it
                 set imarker(motion) none
                 set imarker(handle) -1
 
@@ -1028,7 +1045,7 @@ proc ControlButton1Frame {which x y} {
 		    MarkerCreate $which $x $y
 		}
 	    } else {
-		# we need this cause MarkerMotion maybe called, 
+		# we need this cause MarkerMotion maybe called,
 		# and we don't want it
 		set imarker(motion) none
 		set imarker(handle) -1
@@ -1039,7 +1056,7 @@ proc ControlButton1Frame {which x y} {
 	    if {$which == $current(frame)} {
 		MarkerControl $which $x $y
 	    } else {
-		# we need this cause MarkerMotion maybe called, 
+		# we need this cause MarkerMotion maybe called,
 		# and we don't want it
 		set imarker(motion) none
 		set imarker(handle) -1
@@ -1083,7 +1100,7 @@ proc ControlShiftButton1Frame {which x y} {
 	    if {$which == $current(frame)} {
 		MarkerControlShift $which $x $y
 	    } else {
-		# we need this cause MarkerMotion maybe called, 
+		# we need this cause MarkerMotion maybe called,
 		# and we don't want it
 		set imarker(motion) none
 		set imarker(handle) -1
@@ -1112,7 +1129,7 @@ proc Motion1Frame {which x y} {
     }
 
     # abort if we are here by accident (such as a double click)
-    if {($ds9(b1) == 0) && ($ds9(sb1) == 0) && 
+    if {($ds9(b1) == 0) && ($ds9(sb1) == 0) &&
 	($ds9(cb1) == 0) && ($ds9(csb1) == 0)} {
 	return
     }
@@ -1214,7 +1231,7 @@ proc Release1Frame {which x y} {
     }
 
     # abort if we are here by accident (such as a double click)
-    if {($ds9(b1) == 0) && ($ds9(sb1) == 0) && 
+    if {($ds9(b1) == 0) && ($ds9(sb1) == 0) &&
 	($ds9(cb1) == 0) && ($ds9(csb1) == 0)} {
 	return
     }
@@ -1569,7 +1586,7 @@ proc KeyFrame {which K A xx yy} {
 
 		z {Zoom 2 2}
 		Z {Zoom .5 .5}
-	    }    
+	    }
 	}
 	crosshair {
 	    switch -- $K {
@@ -1623,21 +1640,21 @@ proc KeyFrame {which K A xx yy} {
 		h {MarkerArrowKey $which -1 0}
 		Right -
 		l {MarkerArrowKey $which 1 0}
-	    }	    
+	    }
 	    CATKey $which $K
 	}
-        footprint {                                                             
-            switch -- $K {                                                      
-                Up -                                                            
-                k {MarkerArrowKey $which 0 -1}                                  
-                Down -                                                          
-                j {MarkerArrowKey $which 0 1}                                   
-                Left -                                                          
-                h {MarkerArrowKey $which -1 0}                                  
-                Right -                                                         
-                l {MarkerArrowKey $which 1 0}                                   
-            }                                                                   
-        }                                                                       
+        footprint {
+            switch -- $K {
+                Up -
+                k {MarkerArrowKey $which 0 -1}
+                Down -
+                j {MarkerArrowKey $which 0 1}
+                Left -
+                h {MarkerArrowKey $which -1 0}
+                Right -
+                l {MarkerArrowKey $which 1 0}
+            }
+        }
 	iexam {IExamKey $which $K $xx $yy}
 	colorbar -
 	crop -
@@ -1934,16 +1951,25 @@ proc UpdateActiveFrames {} {
     # reset active list
     set ds9(active) {}
 
+    set frames {}
     foreach ff $ds9(frames) {
-	if {$active($ff)} {
+	if {![llength [info commands $ff]]} {
+	    catch {unset active($ff)}
+	    continue
+	}
+
+	lappend frames $ff
+	if {[info exists active($ff)] && $active($ff)} {
 	    lappend ds9(active) $ff
 	    $ds9(mb).frame.goto entryconfig \
 		"[msgcat::mc {Frame}] [string range $ff 5 end]" -state normal
 	} else {
+	    set active($ff) 0
 	    $ds9(mb).frame.goto entryconfig \
 		"[msgcat::mc {Frame}] [string range $ff 5 end]" -state disabled
 	}
     }
+    set ds9(frames) $frames
 
     # New layout if needed
     if {[llength $ds9(active)] > 0} {
@@ -1986,9 +2012,15 @@ proc GotoFrame {which} {
     global active
     global view
 
-    if {$current(frame) != {} && $current(frame) != $which} {
-	$current(frame) highlite off
-	$current(frame) panner off
+    if {$which == {} || ![llength [info commands $which]]} {
+	return
+    }
+
+    if {$current(frame) != {} &&
+	$current(frame) != $which &&
+	[llength [info commands $current(frame)]]} {
+	catch {$current(frame) highlite off}
+	catch {$current(frame) panner off}
 
 	switch -- $ds9(display) {
 	    blink -
@@ -1996,21 +2028,21 @@ proc GotoFrame {which} {
 	    single {
 		set ff $current(frame)
 		# frame
-		$ff hide
+		catch {$ff hide}
 
 		# colorbar
 		if {$view(colorbar)} {
-		    ${ff}cb hide
+		    catch {${ff}cb hide}
 		}
 
 		# graphs
 		if {$view(graph,horz)} {
-		    GraphHide $ff horz
+		    catch {GraphHide $ff horz}
 		}
 		if {$view(graph,vert)} {
-		    GraphHide $ff vert
+		    catch {GraphHide $ff vert}
 		}
-		
+
 	    }
 	    tile {}
 	}
@@ -2027,23 +2059,23 @@ proc GotoFrame {which} {
 	}
 
 	# frame
-	$current(frame) show
-	LayoutRaise $current(frame)
+	catch {$current(frame) show}
+	catch {LayoutRaise $current(frame)}
 #	$ds9(canvas) raise $current(frame)
 
 	# colorbar
 	if {$view(colorbar)} {
-	    $current(colorbar) show
-	    LayoutRaise $current(colorbar)
+	    catch {$current(colorbar) show}
+	    catch {LayoutRaise $current(colorbar)}
 #	    $ds9(canvas) raise $current(colorbar)
 	}
 
 	# graphs
 	if {$view(graph,horz)} {
-	    GraphShow $current(frame) horz
+	    catch {GraphShow $current(frame) horz}
 	}
 	if {$view(graph,vert)} {
-	    GraphShow $current(frame) vert
+	    catch {GraphShow $current(frame) vert}
 	}
 
 	FrameToFront
@@ -2098,8 +2130,9 @@ proc DisplayMode {} {
 		set ifade(id) {}
 		set ifade(index) -1
 		set ifade(alpha) 0
-		if {$current(frame) != {}} {
-		    $current(frame) fade clear
+		if {$current(frame) != {} &&
+		    [llength [info commands $current(frame)]]} {
+		    catch {$current(frame) fade clear}
 		}
 	    }
 
@@ -2112,8 +2145,9 @@ proc DisplayMode {} {
 		set ifade(id) {}
 		set ifade(index) -1
 		set ifade(alpha) 0
-		if {$current(frame) != {}} {
-		    $current(frame) fade clear
+		if {$current(frame) != {} &&
+		    [llength [info commands $current(frame)]]} {
+		    catch {$current(frame) fade clear}
 		}
 	    }
 
@@ -2188,14 +2222,14 @@ proc FadeTimer {} {
 
 	set ifade(alpha) 0
     }
-    
+
     # fade
     set next [lindex $ds9(active) $ifade(index)]
     switch [$next get type] {
 	base -
 	rgb {
 	    $current(frame) fade [$next get] $ifade(alpha)
-	    
+
 	    # next time thru
 	    set ifade(alpha) [expr $ifade(alpha)+(100.*$fade(step)/($fade(interval)/2.))]
 
@@ -2307,6 +2341,10 @@ proc ClearFrame {which} {
 	if {[info exists $varname]} {
 	    unset $varname
 	}
+    }
+
+    if {![llength [info commands $which]]} {
+	return
     }
 
     set cnt [$which get fits count]
@@ -2473,7 +2511,7 @@ proc TileApplyDialog {} {
     set tile(grid,row) $dtile(row)
     set tile(grid,col) $dtile(col)
     set tile(grid,gap) $dtile(gap)
-    
+
     DisplayMode
 }
 
@@ -2561,7 +2599,7 @@ proc ProcessSendTileCmd {proc id param {sock {}} {fn {}}} {
 proc TileSendCmd {} {
     global parse
     global current
-    
+
     if {$current(display)=="tile"} {
 	$parse(proc) $parse(id) "yes\n"
     } else {
@@ -2592,7 +2630,7 @@ proc ProcessSendBlinkCmd {proc id param {sock {}} {fn {}}} {
 proc BlinkSendCmd {} {
     global parse
     global current
-    
+
     if {$current(display)=="blink"} {
 	$parse(proc) $parse(id) "yes\n"
     } else {
@@ -2630,7 +2668,7 @@ proc ProcessSendFadeCmd {proc id param {sock {}} {fn {}}} {
 proc FadeSendCmd {} {
     global parse
     global current
-    
+
     if {$current(display)=="fade"} {
 	$parse(proc) $parse(id) "yes\n"
     } else {

--- a/ds9/library/marker.tcl
+++ b/ds9/library/marker.tcl
@@ -16,6 +16,7 @@ proc MarkerDef {} {
     set imarker(handle) -1
     set imarker(prefix,dialog) {mkr}
     set imarker(prefix,plot3d) {mkrplot3d}
+    set imarker(prefix,cutout3d) {mkrcutout3d}
     set imarker(prefix,plot2d) {mkrplot2d}
     set imarker(prefix,stats) {stats}
     set imarker(prefix,radial) {mkrradial}

--- a/ds9/library/markeranalysisplot3d.tcl
+++ b/ds9/library/markeranalysisplot3d.tcl
@@ -75,6 +75,20 @@ proc MarkerAnalysisPlot3dApplyColorbar {frame cutout} {
     catch {${cutout}cb colorbar [$cutout get colorbar]}
 }
 
+proc MarkerAnalysisPlot3dApplyScaleLimits {frame cutout} {
+    if {![MarkerAnalysisPlot3dFrameExists $frame] ||
+	![MarkerAnalysisPlot3dFrameExists $cutout]} {
+	return
+    }
+
+    if {[catch {$frame get clip} limits]} {
+	return
+    }
+
+    catch {eval [list $cutout clip user] $limits}
+    catch {$cutout clip mode user}
+}
+
 proc MarkerAnalysisPlot3dCmd {varname} {
     upvar #0 $varname var
     global $varname
@@ -219,6 +233,7 @@ proc MarkerAnalysisPlot3dCB {frame id} {
 
     catch {GotoFrame $cutout}
     catch {LoadVar $datavar "${frame}.${id}.3d-cutout.fits" {} {}}
+    MarkerAnalysisPlot3dApplyScaleLimits $frame $cutout
     MarkerAnalysisPlot3dApplyColorbar $frame $cutout
     catch {$cutout 3d view 45 30}
     catch {$cutout zoom to fit}

--- a/ds9/library/markeranalysisplot3d.tcl
+++ b/ds9/library/markeranalysisplot3d.tcl
@@ -240,12 +240,6 @@ proc MarkerAnalysisPlot3dDeleteCB {frame id} {
     upvar #0 $vvarname vvar
     global $vvarname
 
-    if {[info exists vvar(cutoutframe)]} {
-	set cutout $vvar(cutoutframe)
-	if {[MarkerAnalysisPlot3dFrameExists $cutout]} {
-	    catch {DeleteFrame $cutout}
-	}
-    }
     catch {unset vvar}
 }
 
@@ -259,7 +253,21 @@ proc MarkerAnalysisPlot3dUpdateColorbar {frame} {
 	    $vvar(frame) == $frame &&
 	    [info exists vvar(cutoutframe)] &&
 	    [MarkerAnalysisPlot3dFrameExists $vvar(cutoutframe)]} {
-	    MarkerAnalysisPlot3dApplyColorbar $frame $vvar(cutoutframe)
+	    MarkerAnalysisPlot3dCB $vvar(frame) $vvar(id)
+	}
+    }
+}
+
+proc MarkerAnalysisPlot3dUpdateScale {frame} {
+    global imarker
+
+    foreach vvarname [info globals ${imarker(prefix,plot3d)}*] {
+	upvar #0 $vvarname vvar
+	if {[info exists vvar(frame)] &&
+	    $vvar(frame) == $frame &&
+	    [info exists vvar(id)] &&
+	    [MarkerAnalysisPlot3dFrameExists $frame]} {
+	    MarkerAnalysisPlot3dCB $vvar(frame) $vvar(id)
 	}
     }
 }

--- a/ds9/library/markeranalysisplot3d.tcl
+++ b/ds9/library/markeranalysisplot3d.tcl
@@ -75,7 +75,10 @@ proc MarkerAnalysisPlot3dApplyColorbar {frame cutout} {
     catch {${cutout}cb colorbar [$cutout get colorbar]}
 }
 
-proc MarkerAnalysisPlot3dApplyScaleLimits {frame cutout} {
+proc MarkerAnalysisPlot3dApplyScaleLimits {frame cutout vvarname} {
+    upvar #0 $vvarname vvar
+    global $vvarname
+
     if {![MarkerAnalysisPlot3dFrameExists $frame] ||
 	![MarkerAnalysisPlot3dFrameExists $cutout]} {
 	return
@@ -85,8 +88,17 @@ proc MarkerAnalysisPlot3dApplyScaleLimits {frame cutout} {
 	return
     }
 
+    if {[info exists vvar(scaleLimits)] &&
+	[info exists vvar(scaleFrame)] &&
+	$vvar(scaleLimits) == $limits &&
+	$vvar(scaleFrame) == $cutout} {
+	return
+    }
+
     catch {eval [list $cutout clip user] $limits}
     catch {$cutout clip mode user}
+    set vvar(scaleLimits) $limits
+    set vvar(scaleFrame) $cutout
 }
 
 proc MarkerAnalysisPlot3dCmd {varname} {
@@ -233,7 +245,7 @@ proc MarkerAnalysisPlot3dCB {frame id} {
 
     catch {GotoFrame $cutout}
     catch {LoadVar $datavar "${frame}.${id}.3d-cutout.fits" {} {}}
-    MarkerAnalysisPlot3dApplyScaleLimits $frame $cutout
+    MarkerAnalysisPlot3dApplyScaleLimits $frame $cutout $vvarname
     MarkerAnalysisPlot3dApplyColorbar $frame $cutout
     catch {$cutout 3d view 45 30}
     catch {$cutout zoom to fit}

--- a/ds9/library/markeranalysisplot3d.tcl
+++ b/ds9/library/markeranalysisplot3d.tcl
@@ -45,6 +45,36 @@ proc MarkerAnalysisPlot3dDialog {varname} {
 
 # support
 
+proc MarkerAnalysisPlot3dFrameExists {frame} {
+    global ds9
+
+    return [expr {$frame != {} &&
+		  [info exists ds9(frames)] &&
+		  [lsearch -exact $ds9(frames) $frame] >= 0 &&
+		  [llength [info commands $frame]]}]
+}
+
+proc MarkerAnalysisPlot3dColorbarExists {frame} {
+    return [expr {$frame != {} &&
+		  [llength [info commands ${frame}cb]]}]
+}
+
+proc MarkerAnalysisPlot3dApplyColorbar {frame cutout} {
+    if {![MarkerAnalysisPlot3dFrameExists $frame] ||
+	![MarkerAnalysisPlot3dFrameExists $cutout] ||
+	![MarkerAnalysisPlot3dColorbarExists $frame] ||
+	![MarkerAnalysisPlot3dColorbarExists $cutout]} {
+	return
+    }
+
+    if {[catch {${frame}cb get colormap} cmap]} {
+	return
+    }
+
+    catch {$cutout colormap $cmap}
+    catch {${cutout}cb colorbar [$cutout get colorbar]}
+}
+
 proc MarkerAnalysisPlot3dCmd {varname} {
     upvar #0 $varname var
     global $varname
@@ -55,6 +85,10 @@ proc MarkerAnalysisPlot3dCmd {varname} {
 proc MarkerAnalysisPlot3d {frame id plot} {
     global imarker
 
+    if {![MarkerAnalysisPlot3dFrameExists $frame]} {
+	return
+    }
+
     $frame marker $id analysis plot3d $plot
     if {$plot} {
 	MarkerAnalysisPlot3dCB $frame $id
@@ -63,7 +97,7 @@ proc MarkerAnalysisPlot3d {frame id plot} {
 	upvar #0 $vvarname vvar
 	global $vvarname
 
-	PlotRaise $vvarname
+	catch {PlotRaise $vvarname}
     } else {
 	MarkerAnalysisPlot3dDeleteCB $frame $id
     }
@@ -117,6 +151,10 @@ proc MarkerAnalysisPlot3dCB {frame id} {
     global ds9
     global tile
 
+    if {![MarkerAnalysisPlot3dFrameExists $frame]} {
+	return
+    }
+
     set varname ${imarker(prefix,dialog)}${id}${frame}
     global $varname
     upvar #0 $varname var
@@ -143,7 +181,7 @@ proc MarkerAnalysisPlot3dCB {frame id} {
 	set vvar(method) average
     }
 
-    if {![$frame has fits]} {
+    if {[catch {$frame has fits} hasfits] || !$hasfits} {
 	return
     }
 
@@ -153,13 +191,17 @@ proc MarkerAnalysisPlot3dCB {frame id} {
     global $datavar
 
     catch {unset $datavar}
-    $frame get marker $id analysis plot3d $datavar __cutout3d image average
+    if {[catch {
+	$frame get marker $id analysis plot3d $datavar __cutout3d image average
+    }]} {
+	return
+    }
     if {![info exists $datavar]} {
 	return
     }
 
     if {![info exists vvar(cutoutframe)] ||
-	[lsearch -exact $ds9(frames) $vvar(cutoutframe)] < 0} {
+	![MarkerAnalysisPlot3dFrameExists $vvar(cutoutframe)]} {
 	set olddisplay $current(display)
 	Create3DFrame
 	set vvar(cutoutframe) $current(frame)
@@ -171,15 +213,18 @@ proc MarkerAnalysisPlot3dCB {frame id} {
     }
 
     set cutout $vvar(cutoutframe)
+    if {![MarkerAnalysisPlot3dFrameExists $cutout]} {
+	return
+    }
 
-    GotoFrame $cutout
-    LoadVar $datavar "${frame}.${id}.3d-cutout.fits" {} {}
-    catch {$cutout colormap [${frame}cb get colormap]}
+    catch {GotoFrame $cutout}
+    catch {LoadVar $datavar "${frame}.${id}.3d-cutout.fits" {} {}}
+    MarkerAnalysisPlot3dApplyColorbar $frame $cutout
     catch {$cutout 3d view 45 30}
     catch {$cutout zoom to fit}
 
-    if {$saveframe != {} && [lsearch -exact $ds9(frames) $saveframe] >= 0} {
-	GotoFrame $saveframe
+    if {[MarkerAnalysisPlot3dFrameExists $saveframe]} {
+	catch {GotoFrame $saveframe}
 	set current(colorbar) $savecolorbar
     }
 }
@@ -196,9 +241,9 @@ proc MarkerAnalysisPlot3dDeleteCB {frame id} {
     global $vvarname
 
     if {[info exists vvar(cutoutframe)]} {
-	global ds9
-	if {[lsearch -exact $ds9(frames) $vvar(cutoutframe)] >= 0} {
-	    DeleteFrame $vvar(cutoutframe)
+	set cutout $vvar(cutoutframe)
+	if {[MarkerAnalysisPlot3dFrameExists $cutout]} {
+	    catch {DeleteFrame $cutout}
 	}
     }
     catch {unset vvar}
@@ -213,8 +258,8 @@ proc MarkerAnalysisPlot3dUpdateColorbar {frame} {
 	if {[info exists vvar(frame)] &&
 	    $vvar(frame) == $frame &&
 	    [info exists vvar(cutoutframe)] &&
-	    [lsearch -exact $ds9(frames) $vvar(cutoutframe)] >= 0} {
-	    catch {$vvar(cutoutframe) colormap [${frame}cb get colormap]}
+	    [MarkerAnalysisPlot3dFrameExists $vvar(cutoutframe)]} {
+	    MarkerAnalysisPlot3dApplyColorbar $frame $vvar(cutoutframe)
 	}
     }
 }
@@ -222,6 +267,10 @@ proc MarkerAnalysisPlot3dUpdateColorbar {frame} {
 # hardcoded marker.C
 proc MarkerAnalysisPlot3dSliceCB {frame id} {
     global imarker
+
+    if {![MarkerAnalysisPlot3dFrameExists $frame]} {
+	return
+    }
 
     set vvarname ${imarker(prefix,plot3d)}${id}${frame}
     upvar #0 $vvarname vvar
@@ -231,8 +280,12 @@ proc MarkerAnalysisPlot3dSliceCB {frame id} {
     # this routine will be called, so check first
 
     if {[info exists ${vvarname}(system)]} {
-	set vvar(slice) \
-	    [$frame get fits slice from image $vvar(system)]
+	if {[catch {
+	    set vvar(slice) \
+		[$frame get fits slice from image $vvar(system)]
+	}]} {
+	    return
+	}
 	MarkerAnalysisPlot3dMarker $vvarname
     }
 }

--- a/ds9/library/markeranalysisplot3d.tcl
+++ b/ds9/library/markeranalysisplot3d.tcl
@@ -20,7 +20,7 @@ proc MarkerAnalysisPlot3dDialog {varname} {
     set var(plot3d) [info exists ${vvarname}(top)]
     set var(method) average
 
-    $var(mb).analysis add checkbutton -label [msgcat::mc {Plot 3D}] \
+    $var(mb).analysis add checkbutton -label [msgcat::mc {3D Cutout}] \
 	-variable ${varname}(plot3d) \
 	-command "MarkerAnalysisPlot3dCmd $varname"
     $var(mb).analysis add separator
@@ -85,7 +85,6 @@ proc MarkerAnalysisPlot3dMethod {varname} {
     if {[info exists var(plot3d)]} {
 	if {$var(plot3d)} {
 	    MarkerAnalysisPlot3dCB $frame $id
-	    MarkerAnalysisPlot3dAxisTitle $vvarname
 	}
     }
 }
@@ -106,7 +105,6 @@ proc MarkerAnalysisPlot3dSystem {varname} {
     if {[info exists var(plot3d)]} {
 	if {$var(plot3d)} {
 	    MarkerAnalysisPlot3dCB $frame $id
-	    MarkerAnalysisPlot3dAxisTitle $vvarname
 	}
     }
 }
@@ -115,6 +113,9 @@ proc MarkerAnalysisPlot3dSystem {varname} {
 proc MarkerAnalysisPlot3dCB {frame id} {
     global imarker
     global wcs
+    global current
+    global ds9
+    global tile
 
     set varname ${imarker(prefix,dialog)}${id}${frame}
     global $varname
@@ -142,51 +143,45 @@ proc MarkerAnalysisPlot3dCB {frame id} {
 	set vvar(method) average
     }
 
-    # sanity check
-    if {![$frame has wcs 3d $vvar(system)]} {
-	set vvar(system) image
+    if {![$frame has fits]} {
+	return
     }
 
-    set xdata ${vvarname}xx
-    set ydata ${vvarname}yy
-    global $xdata $ydata
+    set saveframe $current(frame)
+    set savecolorbar $current(colorbar)
+    set datavar ${vvarname}fits
+    global $datavar
 
-    if {[info command $xdata] == {}} {
-	blt::vector create $xdata $ydata
+    catch {unset $datavar}
+    $frame get marker $id analysis plot3d $datavar __cutout3d image average
+    if {![info exists $datavar]} {
+	return
     }
-    $frame get marker $id analysis plot3d $xdata $ydata \
-	$vvar(system) $vvar(method)
-    
-    if {![PlotPing $vvarname]} {
-	set vvar(bunit) [string trim [$frame get fits header keyword BUNIT]]
-	if {$vvar(bunit)=={}} {
-	    set vvar(bunit) {Counts}
+
+    if {![info exists vvar(cutoutframe)] ||
+	[lsearch -exact $ds9(frames) $vvar(cutoutframe)] < 0} {
+	set olddisplay $current(display)
+	Create3DFrame
+	set vvar(cutoutframe) $current(frame)
+	if {$olddisplay == "single"} {
+	    set current(display) tile
+	    set tile(mode) grid
+	    DisplayMode
 	}
-	PlotDialog $vvarname [string totitle [$frame get marker $id type]] true
-	PlotAddGraph $vvarname line
-
-	MarkerAnalysisPlot3dAxisTitle $vvarname
-
-	set vvar(markerslice) [$vvar(graph) marker create line -element bar1 \
-			     -outline cyan -linewidth 2 \
-			     -bindtags [list slice]]
-	$vvar(graph) configure -halo 10
-	$vvar(graph) marker bind slice <B1-Motion> \
-	    [list MarkerAnalysisPlot3dMotion $vvarname %x %y]
-
-	set vvar(mode) pointer
-	PlotChangeMode $vvarname
-
-	set vvar(graph,ds,xdata) $xdata
-	set vvar(graph,ds,ydata) $ydata
-	PlotExternal $vvarname xy
     }
 
-    set vvar(slice) [$frame get fits slice from image $vvar(system)]
-    MarkerAnalysisPlot3dMarker $vvarname
+    set cutout $vvar(cutoutframe)
 
-    PlotStats $vvarname
-    PlotList $vvarname
+    GotoFrame $cutout
+    LoadVar $datavar "${frame}.${id}.3d-cutout.fits" {} {}
+    catch {$cutout colormap [${frame}cb get colormap]}
+    catch {$cutout 3d view 45 30}
+    catch {$cutout zoom to fit}
+
+    if {$saveframe != {} && [lsearch -exact $ds9(frames) $saveframe] >= 0} {
+	GotoFrame $saveframe
+	set current(colorbar) $savecolorbar
+    }
 }
 
 # hardcoded marker.C
@@ -200,7 +195,28 @@ proc MarkerAnalysisPlot3dDeleteCB {frame id} {
     upvar #0 $vvarname vvar
     global $vvarname
 
-    PlotDestroy $vvarname
+    if {[info exists vvar(cutoutframe)]} {
+	global ds9
+	if {[lsearch -exact $ds9(frames) $vvar(cutoutframe)] >= 0} {
+	    DeleteFrame $vvar(cutoutframe)
+	}
+    }
+    catch {unset vvar}
+}
+
+proc MarkerAnalysisPlot3dUpdateColorbar {frame} {
+    global imarker
+    global ds9
+
+    foreach vvarname [info globals ${imarker(prefix,plot3d)}*] {
+	upvar #0 $vvarname vvar
+	if {[info exists vvar(frame)] &&
+	    $vvar(frame) == $frame &&
+	    [info exists vvar(cutoutframe)] &&
+	    [lsearch -exact $ds9(frames) $vvar(cutoutframe)] >= 0} {
+	    catch {$vvar(cutoutframe) colormap [${frame}cb get colormap]}
+	}
+    }
 }
 
 # hardcoded marker.C

--- a/ds9/library/markeranalysisplot3d.tcl
+++ b/ds9/library/markeranalysisplot3d.tcl
@@ -226,11 +226,13 @@ proc MarkerAnalysisPlot3dCB {frame id} {
 	return
     }
 
+    set newcutout 0
     if {![info exists vvar(cutoutframe)] ||
 	![MarkerAnalysisPlot3dFrameExists $vvar(cutoutframe)]} {
 	set olddisplay $current(display)
 	Create3DFrame
 	set vvar(cutoutframe) $current(frame)
+	set newcutout 1
 	if {$olddisplay == "single"} {
 	    set current(display) tile
 	    set tile(mode) grid
@@ -243,12 +245,20 @@ proc MarkerAnalysisPlot3dCB {frame id} {
 	return
     }
 
+    set view {}
+    if {!$newcutout} {
+	catch {set view [$cutout get 3d view]}
+    }
+    if {$view == {}} {
+	set view {45 30}
+    }
+
     catch {GotoFrame $cutout}
     catch {LoadVar $datavar "${frame}.${id}.3d-cutout.fits" {} {}}
     MarkerAnalysisPlot3dApplyScaleLimits $frame $cutout $vvarname
     MarkerAnalysisPlot3dApplyColorbar $frame $cutout
-    catch {$cutout 3d view 45 30}
     catch {$cutout zoom to fit}
+    catch {eval [list $cutout 3d view] $view}
 
     if {[MarkerAnalysisPlot3dFrameExists $saveframe]} {
 	catch {GotoFrame $saveframe}

--- a/ds9/library/markeranalysisplot3d.tcl
+++ b/ds9/library/markeranalysisplot3d.tcl
@@ -17,12 +17,27 @@ proc MarkerAnalysisPlot3dDialog {varname} {
     upvar #0 $vvarname vvar
     global $vvarname
 
+    set cvarname ${imarker(prefix,cutout3d)}${id}${frame}
+    upvar #0 $cvarname cvar
+    global $cvarname
+
     set var(plot3d) [info exists ${vvarname}(top)]
+    set var(cutout3d) [info exists ${cvarname}(active)]
     set var(method) average
 
-    $var(mb).analysis add checkbutton -label [msgcat::mc {3D Cutout}] \
+    $var(mb).analysis add checkbutton -label [msgcat::mc {Plot 3D}] \
 	-variable ${varname}(plot3d) \
 	-command "MarkerAnalysisPlot3dCmd $varname"
+    switch -- [$frame get marker $id type] {
+	circle -
+	ellipse -
+	box -
+	polygon {
+	    $var(mb).analysis add checkbutton -label [msgcat::mc {3D Cutout}] \
+		-variable ${varname}(cutout3d) \
+		-command "MarkerAnalysisCutout3dCmd $varname"
+	}
+    }
     $var(mb).analysis add separator
     $var(mb).analysis add cascade \
 	-label [msgcat::mc {Method}] \
@@ -101,11 +116,44 @@ proc MarkerAnalysisPlot3dApplyScaleLimits {frame cutout vvarname} {
     set vvar(scaleFrame) $cutout
 }
 
+proc MarkerAnalysisPlot3dSetCallback {frame id} {
+    global imarker
+
+    if {![MarkerAnalysisPlot3dFrameExists $frame]} {
+	return
+    }
+
+    set enabled 0
+
+    set vvarname ${imarker(prefix,plot3d)}${id}${frame}
+    upvar #0 $vvarname vvar
+    global $vvarname
+    if {[info exists vvar(top)]} {
+	set enabled 1
+    }
+
+    set cvarname ${imarker(prefix,cutout3d)}${id}${frame}
+    upvar #0 $cvarname cvar
+    global $cvarname
+    if {[info exists cvar(active)]} {
+	set enabled 1
+    }
+
+    catch {$frame marker $id analysis plot3d $enabled}
+}
+
 proc MarkerAnalysisPlot3dCmd {varname} {
     upvar #0 $varname var
     global $varname
 
     MarkerAnalysisPlot3d $var(frame) $var(id) $var(plot3d)
+}
+
+proc MarkerAnalysisCutout3dCmd {varname} {
+    upvar #0 $varname var
+    global $varname
+
+    MarkerAnalysisCutout3d $var(frame) $var(id) $var(cutout3d)
 }
 
 proc MarkerAnalysisPlot3d {frame id plot} {
@@ -115,9 +163,8 @@ proc MarkerAnalysisPlot3d {frame id plot} {
 	return
     }
 
-    $frame marker $id analysis plot3d $plot
     if {$plot} {
-	MarkerAnalysisPlot3dCB $frame $id
+	MarkerAnalysisPlot3dUpdate $frame $id
 
 	set vvarname ${imarker(prefix,plot3d)}${id}${frame}
 	upvar #0 $vvarname vvar
@@ -125,8 +172,22 @@ proc MarkerAnalysisPlot3d {frame id plot} {
 
 	catch {PlotRaise $vvarname}
     } else {
-	MarkerAnalysisPlot3dDeleteCB $frame $id
+	MarkerAnalysisPlot3dDestroy $frame $id
     }
+    MarkerAnalysisPlot3dSetCallback $frame $id
+}
+
+proc MarkerAnalysisCutout3d {frame id plot} {
+    if {![MarkerAnalysisPlot3dFrameExists $frame]} {
+	return
+    }
+
+    if {$plot} {
+	MarkerAnalysisCutout3dCB $frame $id
+    } else {
+	MarkerAnalysisCutout3dDelete $frame $id
+    }
+    MarkerAnalysisPlot3dSetCallback $frame $id
 }
 
 proc MarkerAnalysisPlot3dMethod {varname} {
@@ -145,6 +206,7 @@ proc MarkerAnalysisPlot3dMethod {varname} {
     if {[info exists var(plot3d)]} {
 	if {$var(plot3d)} {
 	    MarkerAnalysisPlot3dCB $frame $id
+	    MarkerAnalysisPlot3dAxisTitle $vvarname
 	}
     }
 }
@@ -165,6 +227,7 @@ proc MarkerAnalysisPlot3dSystem {varname} {
     if {[info exists var(plot3d)]} {
 	if {$var(plot3d)} {
 	    MarkerAnalysisPlot3dCB $frame $id
+	    MarkerAnalysisPlot3dAxisTitle $vvarname
 	}
     }
 }
@@ -172,10 +235,29 @@ proc MarkerAnalysisPlot3dSystem {varname} {
 # hardcoded marker.C
 proc MarkerAnalysisPlot3dCB {frame id} {
     global imarker
+
+    if {![MarkerAnalysisPlot3dFrameExists $frame]} {
+	return
+    }
+
+    set vvarname ${imarker(prefix,plot3d)}${id}${frame}
+    upvar #0 $vvarname vvar
+    global $vvarname
+    if {[info exists vvar(top)]} {
+	MarkerAnalysisPlot3dUpdate $frame $id
+    }
+
+    set cvarname ${imarker(prefix,cutout3d)}${id}${frame}
+    upvar #0 $cvarname cvar
+    global $cvarname
+    if {[info exists cvar(active)]} {
+	MarkerAnalysisCutout3dCB $frame $id
+    }
+}
+
+proc MarkerAnalysisPlot3dUpdate {frame id} {
+    global imarker
     global wcs
-    global current
-    global ds9
-    global tile
 
     if {![MarkerAnalysisPlot3dFrameExists $frame]} {
 	return
@@ -207,13 +289,77 @@ proc MarkerAnalysisPlot3dCB {frame id} {
 	set vvar(method) average
     }
 
+    # sanity check
+    if {![$frame has wcs 3d $vvar(system)]} {
+	set vvar(system) image
+    }
+
+    set xdata ${vvarname}xx
+    set ydata ${vvarname}yy
+    global $xdata $ydata
+
+    if {[info command $xdata] == {}} {
+	blt::vector create $xdata $ydata
+    }
+    $frame get marker $id analysis plot3d $xdata $ydata \
+	$vvar(system) $vvar(method)
+
+    if {![PlotPing $vvarname]} {
+	set vvar(bunit) [string trim [$frame get fits header keyword BUNIT]]
+	if {$vvar(bunit)=={}} {
+	    set vvar(bunit) {Counts}
+	}
+	PlotDialog $vvarname [string totitle [$frame get marker $id type]] true
+	PlotAddGraph $vvarname line
+
+	MarkerAnalysisPlot3dAxisTitle $vvarname
+
+	set vvar(markerslice) [$vvar(graph) marker create line -element bar1 \
+			     -outline cyan -linewidth 2 \
+			     -bindtags [list slice]]
+	$vvar(graph) configure -halo 10
+	$vvar(graph) marker bind slice <B1-Motion> \
+	    [list MarkerAnalysisPlot3dMotion $vvarname %x %y]
+
+	set vvar(mode) pointer
+	PlotChangeMode $vvarname
+
+	set vvar(graph,ds,xdata) $xdata
+	set vvar(graph,ds,ydata) $ydata
+	PlotExternal $vvarname xy
+    }
+
+    set vvar(slice) [$frame get fits slice from image $vvar(system)]
+    MarkerAnalysisPlot3dMarker $vvarname
+
+    PlotStats $vvarname
+    PlotList $vvarname
+}
+
+proc MarkerAnalysisCutout3dCB {frame id} {
+    global imarker
+    global current
+    global tile
+
+    if {![MarkerAnalysisPlot3dFrameExists $frame]} {
+	return
+    }
+
+    set cvarname ${imarker(prefix,cutout3d)}${id}${frame}
+    upvar #0 $cvarname cvar
+    global $cvarname
+
+    set cvar(active) 1
+    set cvar(frame) $frame
+    set cvar(id) $id
+
     if {[catch {$frame has fits} hasfits] || !$hasfits} {
 	return
     }
 
     set saveframe $current(frame)
     set savecolorbar $current(colorbar)
-    set datavar ${vvarname}fits
+    set datavar ${cvarname}fits
     global $datavar
 
     catch {unset $datavar}
@@ -227,11 +373,11 @@ proc MarkerAnalysisPlot3dCB {frame id} {
     }
 
     set newcutout 0
-    if {![info exists vvar(cutoutframe)] ||
-	![MarkerAnalysisPlot3dFrameExists $vvar(cutoutframe)]} {
+    if {![info exists cvar(cutoutframe)] ||
+	![MarkerAnalysisPlot3dFrameExists $cvar(cutoutframe)]} {
 	set olddisplay $current(display)
 	Create3DFrame
-	set vvar(cutoutframe) $current(frame)
+	set cvar(cutoutframe) $current(frame)
 	set newcutout 1
 	if {$olddisplay == "single"} {
 	    set current(display) tile
@@ -240,7 +386,7 @@ proc MarkerAnalysisPlot3dCB {frame id} {
 	}
     }
 
-    set cutout $vvar(cutoutframe)
+    set cutout $cvar(cutoutframe)
     if {![MarkerAnalysisPlot3dFrameExists $cutout]} {
 	return
     }
@@ -255,7 +401,7 @@ proc MarkerAnalysisPlot3dCB {frame id} {
 
     catch {GotoFrame $cutout}
     catch {LoadVar $datavar "${frame}.${id}.3d-cutout.fits" {} {}}
-    MarkerAnalysisPlot3dApplyScaleLimits $frame $cutout $vvarname
+    MarkerAnalysisPlot3dApplyScaleLimits $frame $cutout $cvarname
     MarkerAnalysisPlot3dApplyColorbar $frame $cutout
     catch {$cutout zoom to fit}
     catch {eval [list $cutout 3d view] $view}
@@ -271,26 +417,40 @@ proc MarkerAnalysisPlot3dDeleteCB {frame id} {
     # this routine could be called by the region 
     # after the dialog has been deleted
 
+    MarkerAnalysisPlot3dDestroy $frame $id
+    MarkerAnalysisCutout3dDelete $frame $id
+}
+
+proc MarkerAnalysisPlot3dDestroy {frame id} {
     global imarker
 
     set vvarname ${imarker(prefix,plot3d)}${id}${frame}
     upvar #0 $vvarname vvar
     global $vvarname
 
-    catch {unset vvar}
+    catch {PlotDestroy $vvarname}
+}
+
+proc MarkerAnalysisCutout3dDelete {frame id} {
+    global imarker
+
+    set cvarname ${imarker(prefix,cutout3d)}${id}${frame}
+    upvar #0 $cvarname cvar
+    global $cvarname
+
+    catch {unset cvar}
 }
 
 proc MarkerAnalysisPlot3dUpdateColorbar {frame} {
     global imarker
-    global ds9
 
-    foreach vvarname [info globals ${imarker(prefix,plot3d)}*] {
-	upvar #0 $vvarname vvar
-	if {[info exists vvar(frame)] &&
-	    $vvar(frame) == $frame &&
-	    [info exists vvar(cutoutframe)] &&
-	    [MarkerAnalysisPlot3dFrameExists $vvar(cutoutframe)]} {
-	    MarkerAnalysisPlot3dCB $vvar(frame) $vvar(id)
+    foreach cvarname [info globals ${imarker(prefix,cutout3d)}*] {
+	upvar #0 $cvarname cvar
+	if {[info exists cvar(frame)] &&
+	    $cvar(frame) == $frame &&
+	    [info exists cvar(cutoutframe)] &&
+	    [MarkerAnalysisPlot3dFrameExists $cvar(cutoutframe)]} {
+	    MarkerAnalysisCutout3dCB $cvar(frame) $cvar(id)
 	}
     }
 }
@@ -298,13 +458,13 @@ proc MarkerAnalysisPlot3dUpdateColorbar {frame} {
 proc MarkerAnalysisPlot3dUpdateScale {frame} {
     global imarker
 
-    foreach vvarname [info globals ${imarker(prefix,plot3d)}*] {
-	upvar #0 $vvarname vvar
-	if {[info exists vvar(frame)] &&
-	    $vvar(frame) == $frame &&
-	    [info exists vvar(id)] &&
+    foreach cvarname [info globals ${imarker(prefix,cutout3d)}*] {
+	upvar #0 $cvarname cvar
+	if {[info exists cvar(frame)] &&
+	    $cvar(frame) == $frame &&
+	    [info exists cvar(id)] &&
 	    [MarkerAnalysisPlot3dFrameExists $frame]} {
-	    MarkerAnalysisPlot3dCB $vvar(frame) $vvar(id)
+	    MarkerAnalysisCutout3dCB $cvar(frame) $cvar(id)
 	}
     }
 }

--- a/ds9/library/scale.tcl
+++ b/ds9/library/scale.tcl
@@ -191,6 +191,7 @@ proc UpdateScale {} {
     UpdateContourScale
     UpdateInfoBoxFrame $current(frame)
     UpdateGraphAxes $current(frame)
+    MarkerAnalysisPlot3dUpdateScale $current(frame)
     UpdateMain
 }
 

--- a/fitsy/var.C
+++ b/fitsy/var.C
@@ -8,6 +8,8 @@
 
 FitsVar::FitsVar(Tcl_Interp* interp, const char* var, const char* fn)
 {
+  obj = NULL;
+
   parse(fn);
   if (!valid_)
     return;
@@ -20,24 +22,18 @@ FitsVar::FitsVar(Tcl_Interp* interp, const char* var, const char* fn)
   if (!obj)
     return;
 
-  // just in case
-  Tcl_ConvertToType(interp, obj, Tcl_GetObjType("bytearray"));
-
-  typedef struct ByteArray {
-    int used;			/* The number of bytes used in the byte
-				 * array. */
-    int allocated;		/* The amount of space actually allocated
-				 * minus 1 byte. */
-    unsigned char bytes[4];	/* The array of bytes.  The actual size of
-				 * this field depends on the 'allocated' field
-				 * above. */
-  } ByteArray;
-
-  ByteArray* ba = (ByteArray*)(obj->internalRep.otherValuePtr);
-  mapsize_ = ba->used;
-  mapdata_ = (char*)ba->bytes;
-
   Tcl_IncrRefCount(obj);
+
+  Tcl_Size objLen = 0;
+  unsigned char* bytes = Tcl_GetByteArrayFromObj(obj, &objLen);
+  if (!bytes) {
+    Tcl_DecrRefCount(obj);
+    obj = NULL;
+    return;
+  }
+
+  mapsize_ = objLen;
+  mapdata_ = (char*)bytes;
 
   // so far, so good
   valid_ = 1;
@@ -48,6 +44,5 @@ FitsVar::~FitsVar()
   if (obj)
     Tcl_DecrRefCount(obj);
 }
-
 
 

--- a/tksao/frame/base.C
+++ b/tksao/frame/base.C
@@ -340,6 +340,8 @@ Base::Base(Tcl_Interp* i, Tk_Canvas c, Tk_Item* item)
 
   colorCount = 0;
   colorCells = NULL;
+  colorbarBias = 0.5;
+  colorbarContrast = 1.0;
 
   byteorder_ = 0;
   bitsperpixel_ = 0;

--- a/tksao/frame/base.h
+++ b/tksao/frame/base.h
@@ -141,6 +141,8 @@ public:
 
   int colorCount;               // number of dynamic colors
   unsigned char* colorCells;    // current color values
+  float colorbarBias;           // current colormap bias
+  float colorbarContrast;       // current colormap contrast
 
   int byteorder_;
   int bitsperpixel_;

--- a/tksao/frame/base.h
+++ b/tksao/frame/base.h
@@ -391,6 +391,7 @@ public:
 			   Marker::AnalysisMethod);
   int markerAnalysisPlot3d(Marker*, double**, double**, const BBox&,
 			   Coord::CoordSystem, Marker::AnalysisMethod);
+  void markerAnalysisCutout3d(Marker*, const char*, const BBox&);
   int markerAnalysisRadial(Marker*, double**, double**, double**, 
 			   int, Vector*, BBox*, Coord::CoordSystem);
   int markerAnalysisPanda(Marker*, double**, double**, double**, 

--- a/tksao/frame/box.C
+++ b/tksao/frame/box.C
@@ -222,6 +222,11 @@ void Box::analysisPlot3d(char* xname, char* yname,
   bb.bound(Vector( vv[0],-vv[1]) * mm);
   bb.bound(Vector(-vv[0], vv[1]) * mm);
 
+  if (!strcmp(yname, "__cutout3d")) {
+    parent->markerAnalysisCutout3d(this, xname, bb);
+    return;
+  }
+
   int num = parent->markerAnalysisPlot3d(this, &x, &y, bb, sys, method);
   analysisXYResult(xname, yname, x, y, num);
 }
@@ -420,4 +425,3 @@ void Box::listSAOimage(ostream& str, int strip)
 
   listSAOimagePost(str, strip);
 }
-

--- a/tksao/frame/circle.C
+++ b/tksao/frame/circle.C
@@ -181,6 +181,12 @@ void Circle::analysisPlot3d(char* xname, char* yname,
   Vector ll = -annuli_[0] * Translate(center);
   Vector ur =  annuli_[0] * Translate(center);
   BBox bb(ll,ur) ;
+
+  if (!strcmp(yname, "__cutout3d")) {
+    parent->markerAnalysisCutout3d(this, xname, bb);
+    return;
+  }
+
   int num = parent->markerAnalysisPlot3d(this, &x, &y, bb, sys, method);
   analysisXYResult(xname, yname, x, y, num);
 }
@@ -351,4 +357,3 @@ void Circle::setComposite(const Matrix& mx, double aa)
   center *= mx;
   updateBBox();
 }
-

--- a/tksao/frame/ellipse.C
+++ b/tksao/frame/ellipse.C
@@ -196,6 +196,11 @@ void Ellipse::analysisPlot3d(char* xname, char* yname,
   bb.bound(Vector( vv[0],-vv[1]) * mm);
   bb.bound(Vector(-vv[0], vv[1]) * mm);
 
+  if (!strcmp(yname, "__cutout3d")) {
+    parent->markerAnalysisCutout3d(this, xname, bb);
+    return;
+  }
+
   int num = parent->markerAnalysisPlot3d(this, &x, &y, bb, sys, method);
   analysisXYResult(xname, yname, x, y, num);
 }

--- a/tksao/frame/frame.C
+++ b/tksao/frame/frame.C
@@ -816,6 +816,8 @@ void Frame::colormapCmd(int id, float b, float c, int i, int cnt)
   cmapID = id;
   bias = b;
   contrast = c;
+  colorbarBias = b;
+  colorbarContrast = c;
   invert = i;
 
   updateColorCells(cnt);

--- a/tksao/frame/frame3d.C
+++ b/tksao/frame/frame3d.C
@@ -1122,6 +1122,8 @@ void Frame3d::colormapCmd(int id, float b, float c, int i, int cnt)
   cmapID = id;
   bias = b;
   contrast = c;
+  colorbarBias = b;
+  colorbarContrast = c;
   invert = i;
 
   updateColorCells(cnt);

--- a/tksao/frame/frblt.C
+++ b/tksao/frame/frblt.C
@@ -313,14 +313,13 @@ void Base::markerAnalysisCutout3d(Marker* pp, const char* varname,
   FrScale::ColorScaleType scaleType = currentContext->colorScaleType();
   float expo = currentContext->expo();
   double* hist = currentContext->histequ();
-  int yscale = max(width, depth);
+  int height = max(1, max(width, depth));
 
   float* plane = new float[width*depth];
   int* heights = new int[width*depth];
   memset(plane, 0, width*depth*sizeof(float));
   memset(heights, 0, width*depth*sizeof(int));
 
-  int hmax = 0;
   Matrix bck = pp->bckMatrix();
 
   SETSIGBUS
@@ -337,18 +336,16 @@ void Base::markerAnalysisCutout3d(Marker* pp, const char* varname,
 					    scaleType, expo, hist,
 					    HISTEQUSIZE, colorbarBias,
 					    colorbarContrast, invert);
-	    int height = index ? (index*yscale + colorCount - 1)/colorCount : 0;
+	    int scaledHeight = (index*height)/colorCount;
+	    if (scaledHeight >= height)
+	      scaledHeight = height - 1;
 	    plane[ndx] = val;
-	    heights[ndx] = height;
-	    if (height > hmax)
-	      hmax = height;
+	    heights[ndx] = scaledHeight;
 	  }
 	}
       }
     }
   CLEARSIGBUS
-
-  int height = max(1, hmax + 1);
 
   std::string fits;
   appendFitsCard(fits, "SIMPLE", "T");

--- a/tksao/frame/frblt.C
+++ b/tksao/frame/frblt.C
@@ -337,7 +337,7 @@ void Base::markerAnalysisCutout3d(Marker* pp, const char* varname,
 					    scaleType, expo, hist,
 					    HISTEQUSIZE, colorbarBias,
 					    colorbarContrast, invert);
-	    int height = index ? (index + yscale - 1)/yscale : 0;
+	    int height = index ? (index*yscale + colorCount - 1)/colorCount : 0;
 	    plane[ndx] = val;
 	    heights[ndx] = height;
 	    if (height > hmax)

--- a/tksao/frame/frblt.C
+++ b/tksao/frame/frblt.C
@@ -307,10 +307,20 @@ void Base::markerAnalysisCutout3d(Marker* pp, const char* varname,
   if (width <= 0 || depth <= 0)
     return;
 
-  float* plane = new float[width*depth];
-  memset(plane, 0, width*depth*sizeof(float));
+  int colorCount = this->colorCount > 0 ? this->colorCount : 1;
+  double low = ptr->low();
+  double high = ptr->high();
+  FrScale::ColorScaleType scaleType = currentContext->colorScaleType();
+  float expo = currentContext->expo();
+  double* hist = currentContext->histequ();
+  int yscale = max(width, depth);
 
-  double vmax = 0;
+  float* plane = new float[width*depth];
+  int* heights = new int[width*depth];
+  memset(plane, 0, width*depth*sizeof(float));
+  memset(heights, 0, width*depth*sizeof(int));
+
+  int hmax = 0;
   Matrix bck = pp->bckMatrix();
 
   SETSIGBUS
@@ -321,17 +331,24 @@ void Base::markerAnalysisCutout3d(Marker* pp, const char* varname,
 	  pp->isIn(rr*ptr->dataToRef,bck);
 	if (inside) {
 	  double val = ptr->getValueDouble(long(jj)*srcw+long(ii));
-	  if (isfinite(val) && val > 0) {
-	    plane[(jj-ymin)*width + (ii-xmin)] = val;
-	    if (val > vmax)
-	      vmax = val;
+	  if (isfinite(val)) {
+	    int ndx = (jj-ymin)*width + (ii-xmin);
+	    int index = FrScale::colorIndex(val, low, high, colorCount,
+					    scaleType, expo, hist,
+					    HISTEQUSIZE, colorbarBias,
+					    colorbarContrast, invert);
+	    int height = index ? (index + yscale - 1)/yscale : 0;
+	    plane[ndx] = val;
+	    heights[ndx] = height;
+	    if (height > hmax)
+	      hmax = height;
 	  }
 	}
       }
     }
   CLEARSIGBUS
 
-  int height = max(1, (int)ceil(vmax) + 1);
+  int height = max(1, hmax + 1);
 
   std::string fits;
   appendFitsCard(fits, "SIMPLE", "T");
@@ -353,8 +370,9 @@ void Base::markerAnalysisCutout3d(Marker* pp, const char* varname,
   for (int kk=0; kk<depth; kk++)
     for (int jj=0; jj<height; jj++)
       for (int ii=0; ii<width; ii++) {
-	float val = plane[kk*width + ii];
-	appendFitsFloat(fits, val >= jj ? val : 0);
+	int ndx = kk*width + ii;
+	float val = plane[ndx];
+	appendFitsFloat(fits, heights[ndx] >= jj ? val : 0);
       }
 
   padFitsBlock(fits);
@@ -365,6 +383,7 @@ void Base::markerAnalysisCutout3d(Marker* pp, const char* varname,
   }
 
   delete [] plane;
+  delete [] heights;
 }
 
 int Base::markerAnalysisPlot3d(Marker* pp, double** x, double** y,

--- a/tksao/frame/frblt.C
+++ b/tksao/frame/frblt.C
@@ -13,6 +13,52 @@ extern "C" {
 
 #include "sigbus.h"
 
+#include <string>
+
+static void appendFitsCard(std::string& out, const char* key, const char* value)
+{
+  char card[81];
+  snprintf(card, sizeof(card), "%-8s= %20s", key, value);
+  size_t len = strlen(card);
+  memset(card + len, ' ', 80 - len);
+  card[80] = '\0';
+  out.append(card, 80);
+}
+
+static void appendFitsEnd(std::string& out)
+{
+  char card[81];
+  memset(card, ' ', 80);
+  memcpy(card, "END", 3);
+  card[80] = '\0';
+  out.append(card, 80);
+}
+
+static void padFitsBlock(std::string& out)
+{
+  size_t pad = 2880 - (out.size() % 2880);
+  if (pad != 2880)
+    out.append(pad, ' ');
+}
+
+static void appendFitsFloat(std::string& out, float value)
+{
+  union {
+    float f;
+    unsigned char b[4];
+  } u;
+  u.f = value;
+
+#if WORDS_BIGENDIAN
+  out.append((char*)u.b, 4);
+#else
+  out.push_back(u.b[3]);
+  out.push_back(u.b[2]);
+  out.push_back(u.b[1]);
+  out.push_back(u.b[0]);
+#endif
+}
+
 static int dCompare(const void* a, const void* b)
 {
   double* aa = (double*)a;
@@ -226,6 +272,99 @@ int Base::markerAnalysisPlot2d(Marker* pp, double** x, double** y,
     delete [] marr;
 
   return num;
+}
+
+void Base::markerAnalysisCutout3d(Marker* pp, const char* varname,
+				  const BBox& bb)
+{
+  if (!currentContext || !pp || !varname || !*varname)
+    return;
+
+  FitsImage* ptr = isInCFits(pp->getCenter(),Coord::REF,NULL);
+  if (!ptr)
+    ptr = currentContext->cfits;
+  if (!ptr)
+    return;
+
+  FitsBound* params = ptr->getDataParams(currentContext->secMode());
+  if (!params)
+    return;
+
+  int srcw = ptr->width();
+  if (srcw <= 0)
+    return;
+
+  Vector ll = (bb.ll*ptr->refToData).floor();
+  Vector ur = (bb.ur*ptr->refToData).ceil();
+
+  int xmin = max((int)ll[0], params->xmin);
+  int ymin = max((int)ll[1], params->ymin);
+  int xmax = min((int)ur[0], params->xmax);
+  int ymax = min((int)ur[1], params->ymax);
+
+  int width = xmax - xmin;
+  int depth = ymax - ymin;
+  if (width <= 0 || depth <= 0)
+    return;
+
+  float* plane = new float[width*depth];
+  memset(plane, 0, width*depth*sizeof(float));
+
+  double vmax = 0;
+  Matrix bck = pp->bckMatrix();
+
+  SETSIGBUS
+    for (int jj=ymin; jj<ymax; jj++) {
+      for (int ii=xmin; ii<xmax; ii++) {
+	Vector rr = Vector(ii,jj)+Vector(.5,.5);
+	int inside = pp->isFixed() ? pp->isIn(rr*ptr->dataToRef,Coord::REF) :
+	  pp->isIn(rr*ptr->dataToRef,bck);
+	if (inside) {
+	  double val = ptr->getValueDouble(long(jj)*srcw+long(ii));
+	  if (isfinite(val) && val > 0) {
+	    plane[(jj-ymin)*width + (ii-xmin)] = val;
+	    if (val > vmax)
+	      vmax = val;
+	  }
+	}
+      }
+    }
+  CLEARSIGBUS
+
+  int height = max(1, (int)ceil(vmax) + 1);
+
+  std::string fits;
+  appendFitsCard(fits, "SIMPLE", "T");
+  appendFitsCard(fits, "BITPIX", "-32");
+  appendFitsCard(fits, "NAXIS", "3");
+
+  char buf[64];
+  snprintf(buf, sizeof(buf), "%d", width);
+  appendFitsCard(fits, "NAXIS1", buf);
+  snprintf(buf, sizeof(buf), "%d", height);
+  appendFitsCard(fits, "NAXIS2", buf);
+  snprintf(buf, sizeof(buf), "%d", depth);
+  appendFitsCard(fits, "NAXIS3", buf);
+  appendFitsCard(fits, "BZERO", "0");
+  appendFitsCard(fits, "BSCALE", "1");
+  appendFitsEnd(fits);
+  padFitsBlock(fits);
+
+  for (int kk=0; kk<depth; kk++)
+    for (int jj=0; jj<height; jj++)
+      for (int ii=0; ii<width; ii++) {
+	float val = plane[kk*width + ii];
+	appendFitsFloat(fits, val >= jj ? val : 0);
+      }
+
+  padFitsBlock(fits);
+  Tcl_Obj* obj = Tcl_NewByteArrayObj((unsigned char*)fits.data(), fits.size());
+  if (Tcl_SetVar2Ex(interp, varname, NULL, obj, TCL_GLOBAL_ONLY)) {
+    snprintf(buf, sizeof(buf), "%s %d %d %d", varname, width, height, depth);
+    Tcl_AppendResult(interp, buf, NULL);
+  }
+
+  delete [] plane;
 }
 
 int Base::markerAnalysisPlot3d(Marker* pp, double** x, double** y,
@@ -1117,4 +1256,3 @@ void Base::bltCutFits(double* xx, double* yy, int size, Coord::Orientation axis,
   if (marr)
     delete [] marr;
 }
-

--- a/tksao/frame/frscale.C
+++ b/tksao/frame/frscale.C
@@ -5,6 +5,8 @@
 #include "frscale.h"
 #include "fitsimage.h"
 
+#include <math.h>
+
 FrScale::FrScale()
 {
   colorScaleType_ = LINEARSCALE;
@@ -145,6 +147,87 @@ FrScale& FrScale::operator=(const FrScale& a)
   force_ = a.force_;
 
   return *this;
+}
+
+int FrScale::colorIndex(double value, double low, double high, int count,
+			ColorScaleType scaleType, float expo, double* hist,
+			int histsize, float bias, float contrast, int invert)
+{
+  if (count <= 1)
+    return 0;
+
+  double diff = high - low;
+  if (!isfinite(value) || !isfinite(diff) || diff <= 0)
+    return 0;
+
+  double scaled;
+  if (value <= low)
+    scaled = 0;
+  else if (value >= high)
+    scaled = 1;
+  else
+    scaled = (value - low) / diff;
+
+  switch (scaleType) {
+  case LINEARSCALE:
+  case IISSCALE:
+    break;
+  case LOGSCALE:
+    if (expo > 0 && expo != 1)
+      scaled = log10(expo*scaled + 1) / log10(expo);
+    break;
+  case POWSCALE:
+    if (expo > 0)
+      scaled = (::pow(expo, scaled) - 1) / expo;
+    break;
+  case SQRTSCALE:
+    scaled = sqrt(scaled);
+    break;
+  case SQUAREDSCALE:
+    scaled *= scaled;
+    break;
+  case ASINHSCALE:
+    scaled = asinh(10*scaled) / 3;
+    break;
+  case SINHSCALE:
+    scaled = sinh(3*scaled) / 10;
+    break;
+  case HISTEQUSCALE:
+    if (hist && histsize > 0) {
+      int hh = (int)(scaled * histsize);
+      if (hh < 0)
+	hh = 0;
+      else if (hh >= histsize)
+	hh = histsize - 1;
+      scaled = hist[hh];
+    }
+    break;
+  }
+
+  if (scaled <= 0)
+    scaled = 0;
+  else if (scaled >= 1)
+    scaled = 1;
+
+  int result = (int)(scaled * count);
+  if (result < 0)
+    return 0;
+  if (result >= count)
+    return count - 1;
+
+  if (fabs(bias - 0.5) < 0.0001 && fabs(contrast - 1.0) < 0.0001)
+    return invert ? count - 1 - result : result;
+
+  int ii = invert ? count - 1 - result : result;
+  float bb = invert ? 1 - bias : bias;
+  int adjusted =
+    (int)(((((float)ii / count) - bb) * contrast + .5) * count);
+
+  if (adjusted < 0)
+    return 0;
+  if (adjusted >= count)
+    return count - 1;
+  return adjusted;
 }
 
 double* FrScale::histequ(FitsImage* fits)
@@ -314,4 +397,3 @@ ostream& operator<<(ostream& s, FrScale& fr)
 
   return s;
 }
-

--- a/tksao/frame/frscale.h
+++ b/tksao/frame/frscale.h
@@ -62,6 +62,9 @@ class FrScale {
   FrScale(const FrScale&);
   FrScale& operator=(const FrScale&);
 
+  static int colorIndex(double, double, double, int, ColorScaleType, float,
+			double*, int, float, float, int);
+
   ColorScaleType colorScaleType() {return colorScaleType_;}
   ClipScope clipScope() {return clipScope_;}
   ClipMode clipMode() {return clipMode_;}

--- a/tksao/frame/polygon.C
+++ b/tksao/frame/polygon.C
@@ -325,6 +325,11 @@ void Polygon::analysisPlot3d(char* xname, char* yname,
     bb.bound(vertex.current()->vector * mm);
   while (vertex.next());
 
+  if (!strcmp(yname, "__cutout3d")) {
+    parent->markerAnalysisCutout3d(this, xname, bb);
+    return;
+  }
+
   int num = parent->markerAnalysisPlot3d(this, &x, &y, bb, sys, method);
   analysisXYResult(xname, yname, x, y, num);
 }
@@ -515,4 +520,3 @@ void Polygon::listSAOimage(ostream& str, int strip)
 
   listSAOimagePost(str, strip);
 }
-


### PR DESCRIPTION
A new Region analysis task has been added to Circle, Ellipse, and Polygon shapes: 3D cutout.

Activating this analysis task creates a new 3D frame that renders the pixel values inside the region as a 3D data cube: x, y, and amplitude (eg counts/flux/etc).  The 3D frame is automatically updated when the region is moved, resized, rotated, or otherwise edited. The colormap and colorbar parameters including scaling + limits are kept in sync between the frame with region and the 3D frame containing the cutout. 

Note: Normal back-and-restore works.  However, upon restore, the 3D frame is no longer tied to the region. This is consistent with other analysis tasks that generate plots (plots are backed up, but no longer "live" when restored). 