### PR TITLE
Xpa on win

### DIFF
--- a/ds9/library/ds9.tcl
+++ b/ds9/library/ds9.tcl
@@ -129,8 +129,8 @@ proc DS9Def {} {
     # start XPA
     switch $ds9(wm) {
 	x11 -
-	aqua {set pds9(xpa) 1}
-	win32 {set pds9(xpa) 0}
+	aqua -
+	win32 {set pds9(xpa) 1}
     }
 
     # start hub if unable to find another

--- a/ds9/library/xpa.tcl
+++ b/ds9/library/xpa.tcl
@@ -14,8 +14,8 @@ proc InitXPA {} {
     }
 
     switch -- $ds9(wm) {
-	x11 -
-	win32 {}
+	x11 {}
+	win32 {set env(PATH) "$ds9(root);$env(PATH)"}
 	aqua {set env(PATH) "$ds9(root):$env(PATH)"}
     }
 

--- a/ds9/win/Makefile.in
+++ b/ds9/win/Makefile.in
@@ -84,6 +84,14 @@ LIBDIR	= $(APPDIR)
 
 OBJS	= ds9.o winMain.o ds9.res.o
 
+XPA_TOOLS	= \
+	$(APPDIR)/xpaset.exe \
+	$(APPDIR)/xpaget.exe \
+	$(APPDIR)/xpainfo.exe \
+	$(APPDIR)/xpaaccess.exe \
+	$(APPDIR)/xpans.exe \
+	$(APPDIR)/xpamb.exe
+
 empty:=
 space:=$(empty) $(empty)
 
@@ -158,7 +166,7 @@ PREQS	= \
 	$(LIBDIR)/ttkthemes \
 	$(LIBDIR)/scidthemes \
 	$(LIBDIR)/ssl \
-	$(APPDIR)/xpans.exe \
+	$(XPA_TOOLS) \
 	$(APPDIR)/install.vbs \
 	$(APPDIR)/tcc \
 	DLLs
@@ -258,8 +266,8 @@ $(APPDIR)/ssl: $(prefix)/openssl
 	mkdir -p "$@"
 	cp -fv "$(prefix)/certifi/certifi/cacert.pem" "$@"
 
-$(APPDIR)/xpans.exe: $(bindir)/xpans.exe
-	cp -f $? $@
+$(APPDIR)/xpa%.exe: $(bindir)/xpa%.exe
+	cp -f $< $@
 
 $(APPDIR)/install.vbs: install.vbs
 	cp -f $? $@

--- a/ds9/win/ds9.iss
+++ b/ds9/win/ds9.iss
@@ -75,7 +75,7 @@ Source: "..\..\bin\SAOImageDS9\tooltip\*"; DestDir: "{app}\tooltip\"; Flags: ign
 Source: "..\..\bin\SAOImageDS9\ttkthemes\*"; DestDir: "{app}\ttkthemes\"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "..\..\bin\SAOImageDS9\ssl\*"; DestDir: "{app}\ssl\"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "..\..\bin\SAOImageDS9\pdf4tcl\*"; DestDir: "{app}\pdf4tcl\"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "..\..\bin\SAOImageDS9\xpans.exe"; DestDir: "{app}";
+Source: "..\..\bin\SAOImageDS9\xpa*.exe"; DestDir: "{app}";
 
 
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files

--- a/xpa/find.c
+++ b/xpa/find.c
@@ -18,6 +18,12 @@
 
 #define MAXBUFSIZE 8192
 
+#if HAVE_MINGW32
+#define PATHDELIMS ";"
+#else
+#define PATHDELIMS ":;"
+#endif
+
 #ifndef HAVE_UNISTD_H
 #define F_OK            0       /* does file exist */
 #define X_OK            1       /* is it executable by caller */
@@ -79,7 +85,7 @@ static char *findpath(name, mode, path)
   pathbuff[MAXBUFSIZE-1] = '\0';
   path = pathbuff;
 
-  if ( (here = strpbrk(pathbuff, ":;")) ) {
+  if ( (here = strpbrk(pathbuff, PATHDELIMS)) ) {
     mark = *here;
     *here++ = '\0';
   }
@@ -134,7 +140,7 @@ static char *findpath(name, mode, path)
     }
 
     path = here;
-    if ( here && (here = strpbrk(here, ":;")) ) {
+    if ( here && (here = strpbrk(here, PATHDELIMS)) ) {
       mark = *here;
       *here++ = '\0';
     }


### PR DESCRIPTION
Fixed bug causing `xpans.exe` not to be found in `PATH` on Windows.  A `:` cannot be used as a separator, eg `C:\Program Files`.

Enable XPA on windows by default now that bugs have been fixed.  Go ahead an install xpatools in SAOImageDS9 dir.
