### PR TITLE
Region coords pref

### DIFF
--- a/ds9/library/marker.tcl
+++ b/ds9/library/marker.tcl
@@ -75,6 +75,7 @@ proc MarkerDef {} {
 
     set pmarker(epsilon) 3
     set pmarker(dformat) degrees
+    set pmarker(edit,system) 0
     set pmarker(circle,radius) 20
     set pmarker(annulus,inner) 15
     set pmarker(annulus,outer) 30

--- a/ds9/library/marker.tcl
+++ b/ds9/library/marker.tcl
@@ -55,19 +55,16 @@ proc MarkerDef {} {
     set marker(plot3d) 0
     set marker(stats) 0
 
+    # defaults used for region save/load/list
     set marker(format) ds9
-
-    # these are only used for save/load/list and
-    #   are set from current wcs values
+    set marker(system) physical
+    set marker(sky) fk5
+    set marker(skyformat) degrees
     array set pmarker [array get marker]
 
     set marker(copy) {}
     set marker(copy,system) {}
     set marker(load) current
-
-    set marker(system) physical
-    set marker(sky) fk5
-    set marker(skyformat) degrees
     set marker(strip) 0
 
     # temp

--- a/ds9/library/markerbase.tcl
+++ b/ds9/library/markerbase.tcl
@@ -4,6 +4,25 @@
 
 package provide DS9 1.0
 
+proc MarkerBaseCoordInit {varname} {
+    upvar #0 $varname var
+    global $varname
+
+    global pmarker
+
+    if {$pmarker(edit,system)} {
+	set var(system) $pmarker(system)
+	set var(sky) $pmarker(sky)
+	set var(skyformat) $pmarker(skyformat)
+    } elseif {![info exists var(system)]} {
+	set rr [$var(frame) get wcs]
+	set var(system) [lindex $rr 0]
+	set var(sky) [lindex $rr 1]
+	set var(skyformat) [lindex $rr 2]
+    }
+    AdjustCoordSystem $varname system
+}
+
 proc MarkerBaseDialog {varname} {
     upvar #0 $varname var
     global $varname
@@ -15,13 +34,7 @@ proc MarkerBaseDialog {varname} {
     }
 
     # variables - some may already be initialized (compass,ruler)
-    if {![info exists var(system)]} {
-	set rr [$var(frame) get wcs]
-	set var(system) [lindex $rr 0]
-	set var(sky) [lindex $rr 1]
-	set var(skyformat) [lindex $rr 2]
-    }
-    AdjustCoordSystem $varname system
+    MarkerBaseCoordInit $varname
 
     # init
     MarkerBaseTextCB $varname

--- a/ds9/library/markerbaseannulus.tcl
+++ b/ds9/library/markerbaseannulus.tcl
@@ -16,11 +16,7 @@ proc MarkerBaseAnnulusDialog {varname} {
     }
 
     # variables
-    set rr [$var(frame) get wcs]
-    set var(system) [lindex $rr 0]
-    set var(sky) [lindex $rr 1]
-    set var(skyformat) [lindex $rr 2]
-    AdjustCoordSystem $varname system
+    MarkerBaseCoordInit $varname
 
     set var(x) 0
     set var(y) 0

--- a/ds9/library/mregion.tcl
+++ b/ds9/library/mregion.tcl
@@ -376,6 +376,14 @@ proc PrefsDialogRegion {} {
     $f.format.menu add radiobutton -label {X Y} \
 	-variable pmarker(format) -value xy
 
+    # Coordinate System
+    set f [ttk::labelframe $w.region.coordsys \
+	       -text [msgcat::mc {Default Coordinate System}]]
+
+    CoordMenuButton $f.coordsys pmarker system 1 sky skyformat {}
+
+    grid $f.coordsys -padx 2 -pady 2 -sticky w
+
     # Length
     set f [ttk::labelframe $w.region.dformat \
 	       -text [msgcat::mc {Default Length}]]
@@ -509,7 +517,8 @@ proc PrefsDialogRegion {} {
     
     grid $f.title $f.size $f.unit -padx 2 -pady 2 -sticky w
 
-    pack $w.region.format $w.region.dformat $w.region.epsilon \
+    pack $w.region.format $w.region.coordsys \
+	$w.region.dformat $w.region.epsilon \
 	$w.region.centroid $w.region.plot \
 	$w.region.circle $w.region.ellipse \
 	$w.region.box $w.region.polygon $w.region.projection $w.region.point \

--- a/ds9/library/mregion.tcl
+++ b/ds9/library/mregion.tcl
@@ -381,8 +381,12 @@ proc PrefsDialogRegion {} {
 	       -text [msgcat::mc {Default Coordinate System}]]
 
     CoordMenuButton $f.coordsys pmarker system 1 sky skyformat {}
+    ttk::checkbutton $f.edit -text \
+	[msgcat::mc {Use Default Coordinates for Edits}] \
+	-variable pmarker(edit,system)
 
     grid $f.coordsys -padx 2 -pady 2 -sticky w
+    grid $f.edit -padx 2 -pady 2 -sticky w
 
     # Length
     set f [ttk::labelframe $w.region.dformat \

--- a/ds9/library/prefs.tcl
+++ b/ds9/library/prefs.tcl
@@ -1151,9 +1151,6 @@ proc FixPrefs6.0to6.1 {} {
     FixVarRm pmarker(load)
     FixVarRm pmarker(paste,system)
     FixVarRm pmarker(paste,sky)
-    FixVarRm pmarker(system)
-    FixVarRm pmarker(sky)
-    FixVarRm pmarker(skyformat)
     FixVarRm pmarker(strip)
 
     FixVarRm marker(dialog,system)

--- a/ds9/library/wcs.tcl
+++ b/ds9/library/wcs.tcl
@@ -95,12 +95,6 @@ proc UpdateWCS {} {
     set hsv(system) $wcs(system)
     HSVSystem
 
-    # regions
-    global marker
-    set marker(system) $wcs(system)
-    set marker(sky) $wcs(sky)
-    set marker(skyformat) $wcs(skyformat)
-    AdjustCoordSystem marker system
 }
 
 proc LayoutWCSInfoBox {which} {


### PR DESCRIPTION
Add a default coordinates option to prefs which is used for `List` and `Save`.

There is also a checkbox to enable this option to be used when editing regions. Left unchecked (default) it will continue to use the current WCS defined for the frame.