### PR TITLE
Tkmpeg updates

### DIFF
--- a/ds9/library/movie.tcl
+++ b/ds9/library/movie.tcl
@@ -663,8 +663,7 @@ proc MoviePhotoMPEG {} {
     if {$movie(first)} {
 	set ww [image width $ph]
 	set hh [image height $ph]
-	# quality must be >=5, or sometimes will generate bad data
-	mpeg create "$movie(fn)" $ww $hh 25 1 5
+	mpeg create "$movie(fn)" $ww $hh 25 1 1
 	set movie(first) 0
     }
     mpeg add $ph

--- a/make.include
+++ b/make.include
@@ -19,7 +19,7 @@
 # tkcon 2.7.11
 # tkhtml1 1.0.11
 # tkimg 2.0.1
-# tkmpeg 1.0.10
+# tkmpeg 1.1.11
 # tktable 2.12
 
 # ast 9.2.14

--- a/tkagif/tkagif.C
+++ b/tkagif/tkagif.C
@@ -250,13 +250,14 @@ int TkAGIF::add(int argc, const char* argv[])
       return TCL_ERROR;
     }
 
-    unsigned char* src = block.pixelPtr;
     Pixel* dst = pixels;
     for (int jj=0; jj<height_; jj++) {
       for (int ii=0; ii<width_; ii++, dst++) {
-	dst->red = src[(jj*width_+ii)*block.pixelSize+block.offset[0]];
-	dst->green = src[(jj*width_+ii)*block.pixelSize+block.offset[1]];
-	dst->blue = src[(jj*width_+ii)*block.pixelSize+block.offset[2]];
+	unsigned char* src = block.pixelPtr + jj*block.pitch +
+	  ii*block.pixelSize;
+	dst->red = src[block.offset[0]];
+	dst->green = src[block.offset[1]];
+	dst->blue = src[block.offset[2]];
       }
     }
   }

--- a/tkmpeg/ezmpeg.c
+++ b/tkmpeg/ezmpeg.c
@@ -702,6 +702,12 @@ void ezMPEG_EncodeAC(ezMPEGStream *ms, int runlength, int level)
 {
 	int level_abs;
 
+	// MPEG-1 escape-coded AC levels are limited to [-255, 255].
+	if(level > 255)
+		level = 255;
+	else if(level < -255)
+		level = -255;
+
 	level_abs = level < 0 ? -level : level;
 
 	// ac_codes_intra[runlength][0]: Dieser Wert dort gibt an, ob der entsprechende Level

--- a/tkmpeg/ezmpeg.c
+++ b/tkmpeg/ezmpeg.c
@@ -188,13 +188,13 @@ int ezMPEG_Init(ezMPEGStream *ms, const char *outfile, int hsize, int vsize, int
 		return 0;
 	}
 
-	if(hsize < 16 || hsize > 768) {
-		ezMPEG_SetError(ms, "ezMPEG_Init: Horizontal size should be between 16 and 768");
+	if(hsize < 16 || hsize > 4080) {
+		ezMPEG_SetError(ms, "ezMPEG_Init: Horizontal size should be between 16 and 4080");
 		return 0;
 	}
 
-	if(vsize < 16 || vsize > 576) {
-		ezMPEG_SetError(ms, "ezMPEG_Init: Vertical size should be between 16 and 576");
+	if(vsize < 16 || vsize > 4080) {
+		ezMPEG_SetError(ms, "ezMPEG_Init: Vertical size should be between 16 and 4080");
 		return 0;
 	}
 
@@ -295,7 +295,7 @@ void ezMPEG_WriteSequenceHeader(ezMPEGStream *ms)
 
 	ezMPEG_WriteBits(ms, 1, 1);							// marker_bit (1)
 	ezMPEG_WriteBits(ms, 20, 10);						// vbv_buffer_size (20)
-	ezMPEG_WriteBits(ms, 1, 1);							// constrained_parameter_flags (1)
+	ezMPEG_WriteBits(ms, 0, 1);							// constrained_parameter_flags (0)
 	ezMPEG_WriteBits(ms, 0, 1);							// load_intra_quantizer_matrix (0)
 	ezMPEG_WriteBits(ms, 0, 1);							// load_non_intra_quantizer_maxtrix (0)
 

--- a/tkmpeg/tkmpeg.C
+++ b/tkmpeg/tkmpeg.C
@@ -105,8 +105,8 @@ TkMPEG::TkMPEG(Tcl_Interp* intp)
     }
 
     // width and height must be a multiple of 16
-    int ww = int(width/16.+1)*16;
-    int hh = int(height/16.+1)*16;
+    int ww = ((width + 15) / 16) * 16;
+    int hh = ((height + 15) / 16) * 16;
 
     if(!ezMPEG_Init(&ms, argv[2], ww, hh, fps, gop, quality)) {
       Tcl_AppendResult(interp, "ezMPEG_Init ", ezMPEG_GetLastError(&ms), NULL);

--- a/tkmpeg/tkmpeg.C
+++ b/tkmpeg/tkmpeg.C
@@ -152,15 +152,16 @@ int TkMPEG::add(int argc, const char* argv[])
   }
   memset(pict,0,ww*hh*3);
   
-  unsigned char* src = block.pixelPtr;
   unsigned char* dst = pict;
 
   for (int jj=0; jj<hh; jj++)
     for (int ii=0; ii<ww; ii++) {
-      if (jj<height && ii<width) {
-	*dst++ = src[(jj*width+ii)*block.pixelSize+block.offset[0]];
-	*dst++ = src[(jj*width+ii)*block.pixelSize+block.offset[1]];
-	*dst++ = src[(jj*width+ii)*block.pixelSize+block.offset[2]];
+      if (jj<block.height && ii<block.width) {
+	unsigned char* src = block.pixelPtr + jj*block.pitch +
+	  ii*block.pixelSize;
+	*dst++ = src[block.offset[0]];
+	*dst++ = src[block.offset[1]];
+	*dst++ = src[block.offset[2]];
       }
       else {
 	*dst++ = 255;


### PR DESCRIPTION
Update the `tkmpeg` code to allow larger images.  Also fix quantization issue that prevented using lower compression level.  Compression level now set to "1" (best).

Also a fix to `tkagif` and `tkmpeg` that was potentially accessing the wrong array elements when reading from a TkPhoto struct (not using stride/offset).
