### PR TITLE
A few last minute tweaks

### DIFF
--- a/ds9/library/grid.tcl
+++ b/ds9/library/grid.tcl
@@ -32,6 +32,7 @@ proc GridDefault {} {
     set grid(grid,color) cyan
     set grid(grid,width) 1
     set grid(grid,style) 0
+    set grid(grid,dashlist) {8 3}
     set grid(grid,gap1) {}
     set grid(grid,gap2) {}
     set grid(grid,gap3) {}
@@ -44,6 +45,7 @@ proc GridDefault {} {
     set grid(axes,color) cyan
     set grid(axes,width) 1
     set grid(axes,style) 0
+    set grid(axes,dashlist) {8 3}
     set grid(axes,type) interior
     set grid(axes,origin) lll
 
@@ -52,12 +54,14 @@ proc GridDefault {} {
     set grid(tick,color) cyan
     set grid(tick,width) 1
     set grid(tick,style) 0
+    set grid(tick,dashlist) {8 3}
 
     set grid(border) 1
 #    set grid(border,color) blue
     set grid(border,color) cyan
     set grid(border,width) 1
     set grid(border,style) 0
+    set grid(border,dashlist) {8 3}
 
     set grid(format1) {}
     set grid(format2) {}
@@ -166,6 +170,27 @@ proc GridAdjustOptions {which} {
     }
 }
 
+proc GridDashStyle {style dashlist} {
+    global grid
+
+    if {!$grid($style)} {
+	return 0
+    }
+
+    set length [lindex $grid($dashlist) 0]
+    set gap [lindex $grid($dashlist) 1]
+    if {![string is integer -strict $length] ||
+	![string is integer -strict $gap] ||
+	$length < 1 || $length > 255 || $gap < 1 || $gap > 255} {
+	error [msgcat::mc {Dash list values must be integers from 1 through 255.}]
+    }
+
+    # AST line styles are graphics-system-defined integers.  Pack the two
+    # validated bytes into the style so each grid component can carry its
+    # own dash pattern through AST's graphics callback.
+    return [expr {($length << 8) | $gap}]
+}
+
 proc GridBuildOptions {which} {
     global grid
     global current
@@ -176,13 +201,13 @@ proc GridBuildOptions {which} {
     append opt " Grid=$grid(grid),"
     append opt " Colour(grid)=[GridColor2Ast $grid(grid,color)],"
     append opt " Width(grid)=$grid(grid,width),"
-    append opt " Style(grid)=$grid(grid,style),"
+    append opt " Style(grid)=[GridDashStyle grid,style grid,dashlist],"
 
     # Axes
     append opt " DrawAxes=$grid(axes),"
     append opt " Colour(axes)=[GridColor2Ast $grid(axes,color)],"
     append opt " Width(axes)=$grid(axes,width),"
-    append opt " Style(axes)=$grid(axes,style),"
+    append opt " Style(axes)=[GridDashStyle axes,style axes,dashlist],"
 
     # Format
     if {$grid(format1) != {}} {
@@ -221,13 +246,13 @@ proc GridBuildOptions {which} {
     }
     append opt " Colour(ticks)=[GridColor2Ast $grid(tick,color)],"
     append opt " Width(ticks)=$grid(tick,width),"
-    append opt " Style(ticks)=$grid(tick,style),"
+    append opt " Style(ticks)=[GridDashStyle tick,style tick,dashlist],"
 
     # Border
     append opt " Border=$grid(border),"
     append opt " Colour(border)=[GridColor2Ast $grid(border,color)],"
     append opt " Width(border)=$grid(border,width),"
-    append opt " Style(border)=$grid(border,style),"
+    append opt " Style(border)=[GridDashStyle border,style border,dashlist],"
 
     # Labels
     append opt " Labelling=$grid(axes,type),"
@@ -656,7 +681,7 @@ proc GridDialog {} {
     $mb.grid add cascade -label [msgcat::mc {Line}] -menu $mb.grid.line
 
     ColorMenu $mb.grid.color grid grid,color GridApplyDialog
-    GridCreateLineMenu $mb.grid.line grid,width grid,style
+    GridCreateLineMenu $mb.grid.line grid,width grid,style grid,dashlist
 
     # Axes
     ThemeMenu $mb.axes
@@ -669,7 +694,7 @@ proc GridDialog {} {
     $mb.axes add cascade -label [msgcat::mc {Origin}] -menu $mb.axes.origin
 
     ColorMenu $mb.axes.color grid axes,color GridApplyDialog
-    GridCreateLineMenu $mb.axes.line axes,width axes,style
+    GridCreateLineMenu $mb.axes.line axes,width axes,style axes,dashlist
 
     ThemeMenu $mb.axes.origin
     $mb.axes.origin add radiobutton -label [msgcat::mc {Lower Left Front}] \
@@ -731,7 +756,7 @@ proc GridDialog {} {
 	-menu $mb.tick.line
 
     ColorMenu $mb.tick.color grid tick,color GridApplyDialog
-    GridCreateLineMenu $mb.tick.line tick,width tick,style
+    GridCreateLineMenu $mb.tick.line tick,width tick,style tick,dashlist
 
     # Title
     ThemeMenu $mb.title
@@ -755,7 +780,7 @@ proc GridDialog {} {
     $mb.border add cascade -label [msgcat::mc {Line}] -menu $mb.border.line
 
     ColorMenu $mb.border.color grid border,color GridApplyDialog
-    GridCreateLineMenu $mb.border.line border,width border,style
+    GridCreateLineMenu $mb.border.line border,width border,style border,dashlist
 
     # General
     set f [ttk::labelframe $w.general -text [msgcat::mc {Coordinate Grid}] -padding 2]
@@ -785,22 +810,23 @@ proc GridDialog {} {
     ttk::label $f.tgrid -text [msgcat::mc {Grid}]
     ttk::checkbutton $f.gridshow -variable grid(grid) -command GridApplyDialog
     GridCreateColorMenuButton $f.gridcolor grid,color
-    GridCreateLineMenuButton $f.gridline grid,width grid,style
+    GridCreateLineMenuButton $f.gridline grid,width grid,style grid,dashlist
 
     ttk::label $f.taxes -text [msgcat::mc {Axes}]
     ttk::checkbutton $f.axesshow -variable grid(axes) -command GridApplyDialog
     GridCreateColorMenuButton $f.axescolor axes,color
-    GridCreateLineMenuButton $f.axesline axes,width axes,style
+    GridCreateLineMenuButton $f.axesline axes,width axes,style axes,dashlist
 
     ttk::label $f.ttick -text [msgcat::mc {Tickmarks}]
     ttk::checkbutton $f.tickshow -variable grid(tick) -command GridApplyDialog
     GridCreateColorMenuButton $f.tickcolor tick,color
-    GridCreateLineMenuButton $f.tickline tick,width tick,style
+    GridCreateLineMenuButton $f.tickline tick,width tick,style tick,dashlist
 
     ttk::label $f.tborder -text [msgcat::mc {Border}]
     ttk::checkbutton $f.bordershow -variable grid(border) -command GridApplyDialog
     GridCreateColorMenuButton $f.bordercolor border,color
-    GridCreateLineMenuButton $f.borderline border,width border,style
+    GridCreateLineMenuButton $f.borderline border,width border,style \
+	border,dashlist
 
     grid $f.tcomponent $f.tshow $f.tcolor $f.tline \
 	-padx 2 -pady 2 -sticky w
@@ -1181,16 +1207,17 @@ proc GridSetWidgetState {state args} {
     }
 }
 
-proc GridCreateLineMenu {which width dash} {
+proc GridCreateLineMenu {which width dash dashlist} {
     global igrid
     global grid
 
-    WidthDashMenu $which grid $width $dash GridApplyDialog GridApplyDialog
+    WidthDashMenu $which grid $width $dash GridApplyDialog GridApplyDialog \
+	$dashlist GridApplyDialog
 }
 
-proc GridCreateLineMenuButton {which width dash} {
+proc GridCreateLineMenuButton {which width dash dashlist} {
     ttk::menubutton $which -textvariable grid($width) -menu $which.menu
-    GridCreateLineMenu $which.menu $width $dash
+    GridCreateLineMenu $which.menu $width $dash $dashlist
 }
 
 proc GridCreateColorMenuButton {which color} {
@@ -1339,7 +1366,11 @@ proc GridBackup {ch which} {
 	set skyformat [lindex $ll 2]
 	set type [lindex $ll 3]
 	set opts [$which get grid option]
-	set vars [array get grid]
+	set vars [$which get grid var]
+	if {$vars == {}} {
+	    # Grids created by older backup files do not have saved variables.
+	    set vars [array get grid]
+	}
 
 	puts $ch "$which grid create $system $sky $skyformat $type \{\"$opts\"\} \{\"$vars\"\}"
     }

--- a/ds9/library/sia.tcl
+++ b/ds9/library/sia.tcl
@@ -21,6 +21,17 @@ proc SIADef {} {
     set isia(mode) new
     set isia(save) 0
     set psia(registry) {https://dc.g-vo.org/__system__/tap/run/sync}
+    set isia(adql) {SELECT DISTINCT
+  r.ivoid, r.short_name, r.res_title, r.res_description,
+  r.waveband, c.standard_id, i.access_url
+FROM rr.resource AS r
+JOIN rr.capability AS c ON r.ivoid = c.ivoid
+JOIN rr.interface AS i
+  ON c.ivoid = i.ivoid AND c.cap_index = i.cap_index
+WHERE c.standard_id ILIKE 'ivo://ivoa.net/std/sia%'
+  AND i.intf_type = 'vs:paramhttp'
+ORDER BY r.res_title
+}
 
     set isia(def) { \
 			{{AKARI (ISAS/JAXA)} \
@@ -85,6 +96,7 @@ proc SIARegistryDialog {varname} {
     upvar #0 $varname var
     global $varname
     global ds9
+    global isia
 
     set var(top) ".${varname}"
     set var(mb) ".${varname}mb"
@@ -96,7 +108,7 @@ proc SIARegistryDialog {varname} {
     ARInit $varname {}
     set var(proc,exec) SIARegistryExec
     set var(proc,load) SIARegistryLoad
-    set var(proc,error) ARError
+    set var(proc,error) SIARegistryError
     set var(db) ${varname}db
     set var(alldb) ${varname}alldb
     set var(textdb) ${varname}textdb
@@ -107,6 +119,7 @@ proc SIARegistryDialog {varname} {
     set var(filter,ivoid,list) {}
     set var(description,row) 0
     set var(load,pending) 0
+    set var(adql) $isia(adql)
 
     set w $var(top)
     set mb $var(mb)
@@ -136,6 +149,21 @@ proc SIARegistryDialog {varname} {
     grid $f.title $f.text $f.apply $f.clear -padx 2 -pady 2 -sticky ew
     grid columnconfigure $f 1 -weight 1
     bind $f.text <Return> [list SIARegistryFilter $varname]
+
+    set f [ttk::labelframe $w.adql -text [msgcat::mc {ADQL Query}] -padding 2]
+    set var(adql,text) [text $f.text -height 9 -width 70 -wrap none \
+			    -font [font actual TkFixedFont] \
+			    -xscrollcommand [list $f.xscroll set] \
+			    -yscrollcommand [list $f.yscroll set]]
+    ttk::scrollbar $f.yscroll -command [list $var(adql,text) yview] \
+	-orient vertical
+    ttk::scrollbar $f.xscroll -command [list $var(adql,text) xview] \
+	-orient horizontal
+    $var(adql,text) insert 1.0 $var(adql)
+    grid $var(adql,text) $f.yscroll -sticky news
+    grid $f.xscroll -sticky news
+    grid rowconfigure $f 0 -weight 1
+    grid columnconfigure $f 0 -weight 1
 
     set f [ttk::frame $w.tbl]
     set var(tbl) [table $f.t \
@@ -194,6 +222,7 @@ proc SIARegistryDialog {varname} {
     ttk::separator $w.sstatus -orient horizontal
     pack $w.buttons $w.sstatus $w.status -side bottom -fill x
     pack $w.search -side top -fill x
+    pack $w.adql -side top -fill x
     pack $w.description -side bottom -fill x
     pack $w.tbl -side top -fill both -expand true
     bind $w <<Close>> [list SIARegistryDestroy $varname]
@@ -202,6 +231,9 @@ proc SIARegistryDialog {varname} {
 }
 
 proc SIARegistryApply {varname} {
+    upvar #0 $varname var
+
+    set var(adql) [$var(adql,text) get 1.0 end-1c]
     ARApply $varname
     ARStatus $varname [msgcat::mc {Contacting Server}]
     SIARegistryLoad $varname
@@ -213,20 +245,8 @@ proc SIARegistryLoad {varname {url {}} {query {}}} {
 
     if {$url == {}} {
 	set url $psia(registry)
-	set adql {
-	    SELECT DISTINCT
-	      r.ivoid, r.short_name, r.res_title, r.res_description,
-	      r.waveband, c.standard_id, i.access_url
-	    FROM rr.resource AS r
-	    JOIN rr.capability AS c ON r.ivoid = c.ivoid
-	    JOIN rr.interface AS i
-	      ON c.ivoid = i.ivoid AND c.cap_index = i.cap_index
-	    WHERE c.standard_id ILIKE 'ivo://ivoa.net/std/sia%'
-	      AND i.intf_type = 'vs:paramhttp'
-	    ORDER BY r.res_title
-	}
 	set query [http::formatQuery REQUEST doQuery LANG ADQL \
-		       FORMAT votable/td QUERY $adql]
+		       FORMAT votable/td QUERY $var(adql)]
     }
     upvar #0 $var(alldb) A
     catch {array unset A}
@@ -235,13 +255,82 @@ proc SIARegistryLoad {varname {url {}} {query {}}} {
 
 proc SIARegistryExec {varname} {
     upvar #0 $varname var
+    set response [http::data $var(token)]
+    set message [SIARegistryResponseError $var(token)]
+    if {$message != {}} {
+	SIARegistryError $varname $message
+	return
+    }
     VOTParse $var(alldb) $var(token)
+    if {![TBLValidDB $var(alldb)]} {
+	set message [SIARegistryResponseText $response]
+	if {$message == {}} {
+	    set message [msgcat::mc {Unable to parse response from SIA registry}]
+	}
+	SIARegistryError $varname $message
+	return
+    }
     ARDone $varname
     SIARegistryFilter $varname
     if {$var(load,pending)} {
 	set var(load,pending) 0
 	SIARegistryOpen $varname 1
     }
+}
+
+proc SIARegistryResponseError {token} {
+    set response [http::data $token]
+
+    # TAP services report ADQL errors in a VOTable INFO element, often with
+    # HTTP status 200.  Do not mistake that response for an empty result table.
+    set offset 0
+    while {[regexp -nocase -indices -start $offset {<INFO[^>]*>} \
+		$response indices]} {
+	set first [lindex $indices 0]
+	set last [lindex $indices 1]
+	set tag [string range $response $first $last]
+	if {[regexp -nocase \
+		 {name[[:space:]]*=[[:space:]]*["']QUERY_STATUS["']} $tag] &&
+	    [regexp -nocase \
+		 {value[[:space:]]*=[[:space:]]*["']ERROR["']} $tag]} {
+	    if {[regexp -nocase -indices -start [expr {$last + 1}] \
+		    {</INFO[[:space:]]*>} $response endIndices]} {
+		set message [string range $response [expr {$last + 1}] \
+			 [expr {[lindex $endIndices 0] - 1}]]
+		return [SIARegistryResponseText $message]
+	    }
+	    return [msgcat::mc {The SIA registry reported an ADQL error}]
+	}
+	set offset [expr {$last + 1}]
+    }
+
+    set code [http::ncode $token]
+    if {![string is integer -strict $code] || $code < 200 || $code >= 300} {
+	return [SIARegistryResponseText $response]
+    }
+    return {}
+}
+
+proc SIARegistryResponseText {response} {
+    set response [regsub -all -nocase {<script[^>]*>.*</script>} $response { }]
+    set response [regsub -all -nocase {<style[^>]*>.*</style>} $response { }]
+    set response [regsub -all {<[^>]*>} $response { }]
+    set response [XMLUnQuote $response]
+    return [string trim [regsub -all {[[:space:]]+} $response { }]]
+}
+
+proc SIARegistryError {varname message} {
+    upvar #0 $varname var
+
+    if {[info exists var(token)]} {
+	set serverMessage [SIARegistryResponseError $var(token)]
+	if {$serverMessage != {}} {
+	    set message $serverMessage
+	}
+    }
+    SIARegistryDescription $varname $message
+    ARError $varname $message
+    Error $message
 }
 
 proc SIARegistryFilter {varname} {

--- a/ds9/library/util.tcl
+++ b/ds9/library/util.tcl
@@ -1073,7 +1073,14 @@ proc OpenConsole {} {
 	set ::tkcon::OPT(overrideexit) 0
 	set ::tkcon::PRIV(protocol) {tkcon hide}
 
-	tkcon::Init
+	# tkcon uses a fixed light-theme syntax palette.  On Aqua its text
+	# widget otherwise inherits the dark system background while keeping
+	# tkcon's black input foreground, making the console unreadable.
+	if {$ds9(wm) eq {aqua}} {
+	    tkcon::Init -color-bg white
+	} else {
+	    tkcon::Init
+	}
 
 	switch $ds9(wm) {
 	    x11 -

--- a/tksao/tkutil/attribute.C
+++ b/tksao/tkutil/attribute.C
@@ -35,15 +35,15 @@ Attribute::~Attribute()
 
 void Attribute::setStyle(double v)
 {
-  switch ((int)v) {
-  case SOLID:
-  case DASH:
-    break;
-  default:
-    return;
+  int style = (int)v;
+  if (style != SOLID && style != DASH) {
+    int length = (style >> 8) & 0xff;
+    int gap = style & 0xff;
+    if (style < 0x0101 || style > 0xffff || !length || !gap)
+      return;
   }
 
-  style_ = (Style)((int)v);
+  style_ = style;
 }
 
 void Attribute::setWidth(double v)

--- a/tksao/tkutil/attribute.h
+++ b/tksao/tkutil/attribute.h
@@ -19,7 +19,7 @@ class Attribute {
  private:
   Widget* parent;
 
-  Style style_;
+  int style_;
   float width_;
 
   int font_;
@@ -46,7 +46,10 @@ class Attribute {
 
   void setColour(double);
 
-  Style style() {return style_;}
+  int style() {return style_;}
+  int isDash() {return style_ != SOLID;}
+  int dashLength() {return style_ == DASH ? 8 : (style_ >> 8) & 0xff;}
+  int dashGap() {return style_ == DASH ? 3 : style_ & 0xff;}
   float width() {return width_;}
 
   int size() {return size_;}

--- a/tksao/tkutil/gridbase.C
+++ b/tksao/tkutil/gridbase.C
@@ -152,17 +152,15 @@ int GridBase::x11Line(int n, float* x, float* y)
   int w = (int)line_->width();
   if (w<1)
     w = 1;
-  switch (line_->style()) {
-  case Attribute::SOLID:
+  if (!line_->isDash()) {
     XSetLineAttributes(parent_->getDisplay(), gridGC_, w, 
 		       LineSolid, CapButt, JoinMiter);
-    break;
-  case Attribute::DASH:
+  }
+  else {
     XSetLineAttributes(parent_->getDisplay(), gridGC_, w, 
 		       LineOnOffDash, CapButt, JoinMiter);
-    char dlist[] = {8,3};
+    char dlist[] = {(char)line_->dashLength(), (char)line_->dashGap()};
     XSetDashes(parent_->getDisplay(), gridGC_, 0, dlist, 2);
-    break;
   }
 
   for (int i=0; i<n-1; i++) {
@@ -206,14 +204,12 @@ int GridBase::psLine(int n, float* x, float* y)
   }
   {
     ostringstream str;
-    switch (line_->style()) {
-    case Attribute::SOLID:
+    if (!line_->isDash()) {
       str << "[] 0 setdash" << endl << ends;
-      break;
-    case Attribute::DASH:
-      str << "[8 3] 0 setdash" << endl << ends;
-      break;
     }
+    else
+      str << '[' << line_->dashLength() << ' ' << line_->dashGap()
+	  << "] 0 setdash" << endl << ends;
     Tcl_AppendResult(parent_->getInterp(), str.str().c_str(), NULL);
   }
 
@@ -281,14 +277,12 @@ int GridBase::macosxLine(int n, float* x, float* y)
 
   macosxColor(parent_->getXColor(line_->colorName()));
   macosxWidth(line_->width());
-  switch (line_->style()) {
-  case Attribute::SOLID:
+  if (!line_->isDash()) {
     macosxDash(NULL,0);
-    break;
-  case Attribute::DASH:
-    float dlist[] = {8,3};
+  }
+  else {
+    float dlist[] = {(float)line_->dashLength(), (float)line_->dashGap()};
     macosxDash(dlist,2);
-    break;
   }
 
   Vector* v = new Vector[n];
@@ -336,14 +330,12 @@ int GridBase::win32Line(int n, float* x, float* y)
 
   win32Color(parent_->getXColor(line_->colorName()));
   win32Width(line_->width());
-  switch (line_->style()) {
-  case Attribute::SOLID:
+  if (!line_->isDash()) {
     win32Dash(NULL,0);
-    break;
-  case Attribute::DASH:
-    float dlist[] = {8,3};
+  }
+  else {
+    float dlist[] = {(float)line_->dashLength(), (float)line_->dashGap()};
     win32Dash(dlist,2);
-    break;
   }
 
   Vector v[n];


### PR DESCRIPTION
A couple last minute tweaks before cutting b2

- `SIA` now displays the ADQL command. Advanced users can modify/customize.
- `TKCON`: the Tcl/tk console will now use a white background, since the text is always black. (Was unreadable on macos in dark mode)
- `GRID`: extended the exposure of _dash list_ to grids.

The grids work exposed a latent bug that restoring from backup with multiple frames with different grids did not restore correctly (first grid parameters used globally). 