### PR TITLE
Fix uninitialized channel index in ColorbarA causing stale contrast/b…

### DIFF
--- a/tksao/colorbar/colorbara.C
+++ b/tksao/colorbar/colorbara.C
@@ -4,9 +4,11 @@
 
 #include "colorbart.h"
 
-ColorbarA::ColorbarA(Tcl_Interp* i,Tk_Canvas c,Tk_Item* item) 
+ColorbarA::ColorbarA(Tcl_Interp* i,Tk_Canvas c,Tk_Item* item)
   : ColorbarBase(i,c,item)
 {
+  channel = 0;
+
   for (int i=0; i<3; i++) {
     bias[i] = .5;
     contrast[i] = 1.0;


### PR DESCRIPTION
…ias display

ColorbarA::channel was never initialized in the constructor, so a freshly-allocated colorbar object (e.g. after "frame delete" recycles a previously-freed colorbar's heap block) could start with a garbage channel value. In multicolor mode, adjustCmd always writes contrast[0]/bias[0] on drag, but getContrastCmd/getBiasCmd read contrast[channel]/bias[channel] - if channel was nonzero garbage, the Colormap Parameters dialog would read a never-written array slot, showing contrast pinned at 0 and bias as nan while the image itself kept updating correctly.