### PR TITLE
Fix SIGSEGV on single-vertex polygon regions (HLA footprints)

### DIFF
--- a/tksao/frame/polygon.C
+++ b/tksao/frame/polygon.C
@@ -37,7 +37,10 @@ Polygon::Polygon(Base* p, const List<Vertex>& v,
   strcpy(type_, "polygon");
 
   // check to see if the first and last node are the same
-  if (vertex.head()->vector[0] == vertex.tail()->vector[0] &&
+  // (but not when there is only one vertex, where head==tail trivially
+  // and popping it would leave the polygon with no vertices at all)
+  if (vertex.count() > 1 &&
+      vertex.head()->vector[0] == vertex.tail()->vector[0] &&
       vertex.head()->vector[1] == vertex.tail()->vector[1])
     delete vertex.pop();
 }


### PR DESCRIPTION
Polygon's list constructor pops the closing vertex when the first and last points are equal, to de-duplicate an explicitly closed ring. For a 1-vertex polygon head() and tail() are the same node, so the check is trivially true and pops the only vertex, leaving the polygon with zero vertices. BasePolygon::updateHandles then dereferences a null vertex list when the marker is added to its composite, crashing ds9.

This is reproducible with `-footprint hla`, which can return a degenerate single-point polygon in its region data.