### PR TITLE
Windows fits regions wcstab

### DIFF
--- a/ds9/library/autosave.tcl
+++ b/ds9/library/autosave.tcl
@@ -10,7 +10,7 @@ proc AutoSaveDef {} {
     global ds9
 
     set iautosave(id) {}
-    set autosave(fn) [file join [GetEnvHome] "$ds9(app).auto"]
+    set autosave(fn) [file join [GetAppDataHome] "$ds9(app).auto"]
 }
 
 proc AutoSave {} {

--- a/ds9/library/command.tcl
+++ b/ds9/library/command.tcl
@@ -27,9 +27,9 @@ proc ProcessCommandLineFirst {} {
 		wm title $ds9(top) "$tt"
 		wm iconname $ds9(top) $"tt"
 
-		set prefs(dir) [file join [GetEnvHome] ".$ds9(app)"]
+		set prefs(dir) [file join [GetAppDataHome] ".$ds9(app)"]
 		set prefs(fn) [file join $prefs(dir) "$ds9(app).$prefs(version)$prefs(ext)"]
-		set autosave(fn) [file join [GetEnvHome] "$ds9(app).auto"]
+		set autosave(fn) [file join [GetAppDataHome] "$ds9(app).auto"]
 	    }
 	}
 	incr i

--- a/ds9/library/prefs.tcl
+++ b/ds9/library/prefs.tcl
@@ -14,7 +14,7 @@ proc PrefsDef {} {
 
     set prefs(ext) {.prf}
     set prefs(version) [lindex $ds9(version) 0]
-    set prefs(dir) [file join [GetEnvHome] ".$ds9(app)"]
+    set prefs(dir) [file join [GetAppDataHome] ".$ds9(app)"]
     set prefs(fn) [file join $prefs(dir) "$ds9(app).$prefs(version)$prefs(ext)"]
 }
 

--- a/ds9/library/sampclient.tcl
+++ b/ds9/library/sampclient.tcl
@@ -719,7 +719,7 @@ proc SAMPParseHub {} {
     }
 
     if {$fn == {}} {
-	set fn [file join [GetEnvHome] {.samp}]
+	set fn [file join [GetSampHome] {.samp}]
     }
 
     # no hub to be found

--- a/ds9/library/samphub.tcl
+++ b/ds9/library/samphub.tcl
@@ -80,7 +80,7 @@ proc SAMPHubStart {verbose} {
     }
 
     if {$fn == {}} {
-	set fn [file join [GetEnvHome] {.samp}]
+	set fn [file join [GetSampHome] {.samp}]
     }
     set samphub(fn) $fn
 

--- a/ds9/library/utilshare.tcl
+++ b/ds9/library/utilshare.tcl
@@ -53,6 +53,38 @@ proc GetAppDataHome {} {
     return [GetEnvHome]
 }
 
+# home directory as defined by the SAMP standard profile (IVOA
+# REC-SAMP-1.3, sec 4.3.1): HOME on unix-like systems, but USERPROFILE
+# -- not HOMEDRIVE/HOMEPATH -- on windows. this must match what other
+# SAMP clients (e.g. topcat/JSAMP) use to find the .samp lockfile, so
+# it deliberately does NOT consult a windows HOME env var: one may be
+# set (by cygwin, msys, git-bash, conda, ...) to something other than
+# USERPROFILE, which would otherwise point ds9 and other SAMP clients
+# at different lockfile locations and break hub discovery between them.
+proc GetSampHome {} {
+    global env
+    global tcl_platform
+
+    switch $tcl_platform(platform) {
+	unix {
+	    if {[info exists env(HOME)]} {
+		return $env(HOME)
+	    }
+	}
+	windows {
+	    if {[info exists env(USERPROFILE)]} {
+		set hh [file normalize [file nativename $env(USERPROFILE)]]
+		if {[file isdirectory $hh]} {
+		    return $hh
+		}
+	    }
+	}
+    }
+
+    # fallback, in case HOME/USERPROFILE was missing or unusable
+    return [GetEnvHome]
+}
+
 proc ParseURL {url varname} {
     upvar $varname r
 

--- a/ds9/library/utilshare.tcl
+++ b/ds9/library/utilshare.tcl
@@ -30,6 +30,29 @@ proc GetEnvHome {} {
     return {}
 }
 
+# location for ds9-managed persistent state (prefs, autosave, ...).
+# on windows, this is the per-user roaming app data dir, since HOME
+# (or its HOMEDRIVE/HOMEPATH fallback) is not the recommended place for
+# an app to keep its own files. unix/aqua are unaffected.
+proc GetAppDataHome {} {
+    global env
+    global tcl_platform
+
+    switch $tcl_platform(platform) {
+	windows {
+	    if {[info exists env(APPDATA)]} {
+		set hh [file normalize [file nativename $env(APPDATA)]]
+		if {[file isdirectory $hh]} {
+		    return $hh
+		}
+	    }
+	}
+    }
+
+    # unix/aqua, or as a windows fallback if APPDATA is unset/unusable
+    return [GetEnvHome]
+}
+
 proc ParseURL {url varname} {
     upvar $varname r
 

--- a/tksao/frame/basecommand.C
+++ b/tksao/frame/basecommand.C
@@ -10,6 +10,7 @@
 #include "context.h"
 #include "fitsimage.h"
 #include "mmap.h"
+#include "allocgz.h"
 #include "outfile.h"
 #include "outchannel.h"
 #include "outsocket.h"
@@ -839,7 +840,13 @@ void Base::fitsyHasExtCmd(const char* fn)
     return;
   }
 
+  // NB: FitsMMap is a no-op stub on __WIN32 (no mmap()), so probe via
+  // the portable AllocGZ variant there instead
+#ifndef __WIN32
   FitsFile* ext = new FitsFitsMMap(fn, FitsFile::EXACTIMAGE);
+#else
+  FitsFile* ext = new FitsFitsAllocGZ(fn, FitsFile::EXACTIMAGE, FitsFile::NOFLUSH);
+#endif
   if (ext->isValid())
     Tcl_AppendResult(interp, "1", NULL);
   else

--- a/tksao/frame/fitsimage.C
+++ b/tksao/frame/fitsimage.C
@@ -3402,6 +3402,42 @@ Vector3d FitsImage::vDegToRad(const Vector3d& vv, Coord::CoordSystem sys)
   return out;
 }
 
+// return a "next HDU" reader that matches whatever backend actually
+// loaded 'prev', instead of assuming one fixed backend. fitsy's
+// FitsMosaicNext* classes each blindly downcast their 'prev' argument
+// to a pointer of their own backend family (eg FitsMosaicNextMapIncr
+// treats it as a FitsMapIncr*, dereferencing members that only exist
+// in that layout); mismatching that is undefined behavior, not just a
+// wrong answer -- confirmed by a standalone reproduction that SIGBUSes
+// when an AllocGZ-loaded FITS file (ds9's default disk-load backend,
+// see ds9/library/load.tcl) is walked with an MMAPINCR-only next-HDU
+// class. This mirrors the switch on the parent's actual load type
+// that Context::loadMosaicWFPC2 (context.C) already does.
+static FitsFile* fits2NextHDU(FitsFile* prev)
+{
+#ifdef __WIN32
+  // FitsMap/FitsMapIncr (mmap-based) are no-op stubs here (no mmap());
+  // AllocGZ is the portable match for any backend
+  return new FitsMosaicNextAllocGZ(prev, FitsFile::NOFLUSH);
+#else
+  if (dynamic_cast<FitsMapIncr*>(prev))
+    return new FitsMosaicNextMMapIncr(prev);
+  if (dynamic_cast<FitsMap*>(prev))
+    return new FitsMosaicNextMap(prev);
+  if (dynamic_cast<FitsStream<gzFile>*>(prev))
+    return new FitsMosaicNextAllocGZ(prev, FitsFile::NOFLUSH);
+  if (dynamic_cast<FitsStream<FILE*>*>(prev))
+    return new FitsMosaicNextAlloc(prev, FitsFile::NOFLUSH);
+  if (dynamic_cast<FitsStream<Tcl_Channel>*>(prev))
+    return new FitsMosaicNextChannel(prev, FitsFile::NOFLUSH);
+  if (dynamic_cast<FitsStream<int>*>(prev))
+    return new FitsMosaicNextSocket(prev, FitsFile::FLUSH);
+  if (dynamic_cast<FitsStream<gzStream>*>(prev))
+    return new FitsMosaicNextSocketGZ(prev, FitsFile::FLUSH);
+  return NULL;
+#endif
+}
+
 static void fits2TAB(AstFitsChan* chan, const char* extname,
 		     int extver, int extlevel, int* status)
 {
@@ -3413,14 +3449,7 @@ static void fits2TAB(AstFitsChan* chan, const char* extname,
   }
 
   // skip the current HDU
-  // NB: FitsMMapIncr is a no-op stub on __WIN32 (no mmap()), so follow
-  // with the portable AllocGZ variant there instead, matching whatever
-  // 'which' MMAP/MMAPINCR would have picked on unix/macos
-#ifndef __WIN32
-  ext = new FitsMosaicNextMMapIncr(ext);
-#else
-  ext = new FitsMosaicNextAllocGZ(ext, FitsFile::NOFLUSH);
-#endif
+  ext = fits2NextHDU(ext);
 
   while (1) {
     // EOF?
@@ -3443,9 +3472,9 @@ static void fits2TAB(AstFitsChan* chan, const char* extname,
     }
 
     FitsFile* ptr = ext;
-    ext = new FitsMosaicNextMMapIncr(ptr);
+    ext = fits2NextHDU(ptr);
     delete ptr;
-  }  
+  }
 
   // ok, found it
   astClearStatus; // just to make sure

--- a/tksao/frame/fitsimage.C
+++ b/tksao/frame/fitsimage.C
@@ -3402,24 +3402,70 @@ Vector3d FitsImage::vDegToRad(const Vector3d& vv, Coord::CoordSystem sys)
   return out;
 }
 
-// return a "next HDU" reader that matches whatever backend actually
-// loaded 'prev', instead of assuming one fixed backend. fitsy's
-// FitsMosaicNext* classes each blindly downcast their 'prev' argument
-// to a pointer of their own backend family (eg FitsMosaicNextMapIncr
-// treats it as a FitsMapIncr*, dereferencing members that only exist
-// in that layout); mismatching that is undefined behavior, not just a
-// wrong answer -- confirmed by a standalone reproduction that SIGBUSes
-// when an AllocGZ-loaded FITS file (ds9's default disk-load backend,
-// see ds9/library/load.tcl) is walked with an MMAPINCR-only next-HDU
-// class. This mirrors the switch on the parent's actual load type
-// that Context::loadMosaicWFPC2 (context.C) already does.
+// Reopen the target extension fresh, straight from the original file
+// by name+bracket ("file.fits[WCS-TAB]") -- the same technique already
+// used by Base::fitsyHasExtCmd/markerLoadFitsCmd (basecommand.C/
+// frmarker.C) -- rather than continuing to read forward from the
+// parent's existing FitsFile. That distinction matters: by the time
+// this callback runs, Context::load() (context.C) has *already*
+// called img->close() on the freshly-loaded image, once slice/mosaic
+// setup finishes and before WCS setup (FitsImage::block -> resetWCS ->
+// initWCS -> fits2ast) runs. For any FitsStream<T>-based backend --
+// Alloc/AllocGZ/Channel/Socket/SocketGZ -- done() really does close()
+// the underlying handle, so nothing chained off it can be read
+// afterward. mmap-based backends (MMAP/MMAPINCR/SHARE/VAR) don't hit
+// this: their done() is a no-op, so the mapped memory stays valid.
+// That's why this only bites Alloc/AllocGZ-loaded files: ordinary
+// unix/macos disk loads default to mmapincr, but ordinary Windows
+// loads are rewritten to allocgz (see the win32 case in
+// ds9/library/load.tcl's ProcessLoad).
+//
+// Detecting the parent's backend family via RTTI (FitsFile is already
+// polymorphic) and picking the matching class this way -- rather than
+// assuming one fixed backend -- also avoids a second, independent bug:
+// fitsy's FitsMosaicNext* classes each blindly downcast their 'prev'
+// argument to a pointer of their own backend family (eg
+// FitsMosaicNextMapIncr treats it as a FitsMapIncr*, dereferencing
+// members that only exist in that layout), so mismatching that is
+// undefined behavior, not just a wrong answer.
+static FitsFile* fits2OpenExt(FitsFile* orig, const char* extname,
+			      int extver, int extlevel)
+{
+  const char* pname = orig->pName();
+  if (!pname || !pname[0])
+    return NULL;
+
+  int len = strlen(pname) + strlen(extname) + 3;
+  char* buf = new char[len];
+  snprintf(buf, len, "%s[%s]", pname, extname);
+
+  FitsFile* ext = NULL;
+  if (dynamic_cast<FitsMapIncr*>(orig))
+    ext = new FitsFitsMMapIncr(buf, FitsFile::RELAXTABLE);
+  else if (dynamic_cast<FitsMap*>(orig))
+    ext = new FitsFitsMMap(buf, FitsFile::RELAXTABLE);
+  else if (dynamic_cast<FitsStream<gzFile>*>(orig))
+    ext = new FitsFitsAllocGZ(buf, FitsFile::RELAXTABLE, FitsFile::NOFLUSH);
+  else if (dynamic_cast<FitsStream<FILE*>*>(orig))
+    ext = new FitsFitsAlloc(buf, FitsFile::RELAXTABLE, FitsFile::NOFLUSH);
+
+  delete [] buf;
+
+  if (ext && ext->isValid() && ext->isBinTable() &&
+      ext->extver() == extver && ext->extlevel() == extlevel)
+    return ext;
+
+  if (ext)
+    delete ext;
+  return NULL;
+}
+
+// fallback next-HDU walker for backends fits2OpenExt() can't reopen
+// (Channel/Socket/SocketGZ have no reusable filename) -- best effort,
+// continuing from wherever the parent's own handle currently is; see
+// fits2OpenExt()'s comment for why that handle may already be closed
 static FitsFile* fits2NextHDU(FitsFile* prev)
 {
-#ifdef __WIN32
-  // FitsMap/FitsMapIncr (mmap-based) are no-op stubs here (no mmap());
-  // AllocGZ is the portable match for any backend
-  return new FitsMosaicNextAllocGZ(prev, FitsFile::NOFLUSH);
-#else
   if (dynamic_cast<FitsMapIncr*>(prev))
     return new FitsMosaicNextMMapIncr(prev);
   if (dynamic_cast<FitsMap*>(prev))
@@ -3435,45 +3481,48 @@ static FitsFile* fits2NextHDU(FitsFile* prev)
   if (dynamic_cast<FitsStream<gzStream>*>(prev))
     return new FitsMosaicNextSocketGZ(prev, FitsFile::FLUSH);
   return NULL;
-#endif
 }
 
 static void fits2TAB(AstFitsChan* chan, const char* extname,
 		     int extver, int extlevel, int* status)
 {
-  FitsFile* ext = ((FitsImage*)astChannelData)->fitsFile();
+  FitsFile* orig = ((FitsImage*)astChannelData)->fitsFile();
   // just in case
-  if (!ext) {
+  if (!orig) {
     *status = 0;
     return;
   }
 
-  // skip the current HDU
-  ext = fits2NextHDU(ext);
+  FitsFile* ext = fits2OpenExt(orig, extname, extver, extlevel);
 
-  while (1) {
-    // EOF?
-    if (!ext || !ext->isValid()) {
-      if (ext)
-	delete ext;
-      *status = 0;
-      return;
+  if (!ext) {
+    // fallback: walk forward from the parent's current position
+    ext = fits2NextHDU(orig);
+
+    while (1) {
+      // EOF?
+      if (!ext || !ext->isValid()) {
+	if (ext)
+	  delete ext;
+	*status = 0;
+	return;
+      }
+
+      // is it a bin table?
+      if (ext->isBinTable()) {
+	// check its extname
+	const char* name = ext->extname();
+	int ver = ext->extver();
+	int level = ext->extlevel();
+
+	if (name && !strcmp(extname,name) && extver==ver && extlevel==level)
+	  break;
+      }
+
+      FitsFile* ptr = ext;
+      ext = fits2NextHDU(ptr);
+      delete ptr;
     }
-
-    // is it a bin table?
-    if (ext->isBinTable()) {
-      // check its extname
-      const char* name = ext->extname();
-      int ver = ext->extver();
-      int level = ext->extlevel();
-
-      if (name && !strcmp(extname,name) && extver==ver && extlevel==level)
-	break;
-    }
-
-    FitsFile* ptr = ext;
-    ext = fits2NextHDU(ptr);
-    delete ptr;
   }
 
   // ok, found it
@@ -3618,7 +3667,7 @@ AstFrameSet* FitsImage::fits2ast(FitsHead* hd)
   AstFrameSet* frameSet = (AstFrameSet*)astRead(chan);
 
   // do we have anything?
-  if (!astOK || frameSet == AST__NULL || 
+  if (!astOK || frameSet == AST__NULL ||
       strncmp(astGetC(frameSet,"Class"), "FrameSet", 8))
     return NULL;
 

--- a/tksao/frame/fitsimage.C
+++ b/tksao/frame/fitsimage.C
@@ -3413,7 +3413,14 @@ static void fits2TAB(AstFitsChan* chan, const char* extname,
   }
 
   // skip the current HDU
+  // NB: FitsMMapIncr is a no-op stub on __WIN32 (no mmap()), so follow
+  // with the portable AllocGZ variant there instead, matching whatever
+  // 'which' MMAP/MMAPINCR would have picked on unix/macos
+#ifndef __WIN32
   ext = new FitsMosaicNextMMapIncr(ext);
+#else
+  ext = new FitsMosaicNextAllocGZ(ext, FitsFile::NOFLUSH);
+#endif
 
   while (1) {
     // EOF?

--- a/tksao/frame/frmarker.C
+++ b/tksao/frame/frmarker.C
@@ -5170,7 +5170,14 @@ void Base::markerLoadFitsCmd(const char* fn, const char* color)
   // do we have a WCS?
   FitsImage* mkfits = NULL;
   {
+    // NB: FitsMMap is a no-op stub on __WIN32 (no mmap()), so load via
+    // the portable AllocGZ variant there instead
+#ifndef __WIN32
     mkfits = new FitsImageFitsMMap(currentContext, interp, fn, 1);
+#else
+    mkfits = new FitsImageFitsAllocGZ(currentContext, interp, fn, fn,
+				      FitsFile::NOFLUSH, 1);
+#endif
     if (!mkfits || !mkfits->isValid() || !mkfits->isBinTable()) {
       if (mkfits)
 	delete mkfits;


### PR DESCRIPTION
This addresses 4 windows specific bugs

- `WCS-TAB` WCS is now supported.
- FITS region files are now supported.
- Use `%APPDATA` instead of `$HOME` for ds9 preference files and backup files. This is the recommended path to store persistent user application data (esp in networked settings)
- Use `%USERPROFILE` for `.samp` file as per the latest version of the SAMP specification.

This closes #328 #329  and #330 
