### PR TITLE
When a 3rd frame is added to reveal mode, commit to changing to tile …

### DIFF
--- a/ds9/library/frame.tcl
+++ b/ds9/library/frame.tcl
@@ -2177,8 +2177,10 @@ proc DisplayMode {} {
 		set ds9(display) $current(display)
 	    } elseif {[llength $ds9(active)] > 1} {
 		set ds9(display) tile
+		set current(display) tile
 	    } else {
 		set ds9(display) single
+		set current(display) single
 	    }
 	}
     }


### PR DESCRIPTION
…mode rather than leaving state part in tile mode and part in reveal mode.  Same if 2 frames in reveal and one is delete, commit to single frame.

Reported by @DougBurke 

This closes #339 
