### PR TITLE
Samp start

### DIFF
--- a/ds9/library/mfile.tcl
+++ b/ds9/library/mfile.tcl
@@ -1574,18 +1574,31 @@ proc UpdateFileMenuSAMPHub {} {
     global pds9
     global ds9
     global samphub
- 
+    global samp
+
     set mm $ds9(mb).file
     set bb $ds9(buttons).file
 
-    $mm.samphub entryconfig [msgcat::mc {Information}] -state normal
-    $bb.samphubinfo configure -state normal
     if {[info exists samphub]} {
+	# ds9 is hosting the hub
+	$mm.samphub entryconfig [msgcat::mc {Information}] -state normal
+	$bb.samphubinfo configure -state normal
 	$mm.samphub entryconfig [msgcat::mc {Start}] -state disabled
 	$mm.samphub entryconfig [msgcat::mc {Stop}] -state normal
 	$bb.samphubstart configure -state disabled
 	$bb.samphubstop configure -state normal
+    } elseif {[info exists samp]} {
+	# connected to an external hub: we can neither start our own hub
+	# (one is already running) nor stop/inspect someone else's
+	$mm.samphub entryconfig [msgcat::mc {Information}] -state disabled
+	$bb.samphubinfo configure -state disabled
+	$mm.samphub entryconfig [msgcat::mc {Start}] -state disabled
+	$mm.samphub entryconfig [msgcat::mc {Stop}] -state disabled
+	$bb.samphubstart configure -state disabled
+	$bb.samphubstop configure -state disabled
     } else {
+	$mm.samphub entryconfig [msgcat::mc {Information}] -state normal
+	$bb.samphubinfo configure -state normal
 	$mm.samphub entryconfig [msgcat::mc {Start}] -state normal
 	$mm.samphub entryconfig [msgcat::mc {Stop}] -state disabled
 	$bb.samphubstart configure -state normal

--- a/ds9/library/samp.tcl
+++ b/ds9/library/samp.tcl
@@ -835,6 +835,8 @@ proc SAMPErrorInfo {} {
 
 proc SAMPUpdateMenus {} {
     UpdateFileMenuSAMP
+    UpdateFileMenuSAMPHub
+    SAMPHubDialogUpdate
     UpdateCATDialogSAMP
 }
 

--- a/ds9/library/samphubdialog.tcl
+++ b/ds9/library/samphubdialog.tcl
@@ -21,6 +21,7 @@ proc SAMPHubDialog {} {
     set mb $isamphub(mb)
 
     Toplevel $w $mb 6 [msgcat::mc {SAMP Hub}] SAMPHubDestroyDialog
+    wm geometry $w "700x550"
 
     $mb add cascade -label [msgcat::mc {File}] -menu $mb.file
     #~ $mb add cascade -label [msgcat::mc {Edit}] -menu $mb.edit
@@ -94,7 +95,7 @@ proc SAMPHubDialogClient {client} {
     set dsamphub(listbox) [ttk::treeview $f.box \
 			       -yscroll [list $f.scroll set] \
 			       -selectmode browse \
-			       -height 28 \
+			       -height 10 \
 			       -show tree \
 			      ]
 

--- a/ds9/library/wcs.tcl
+++ b/ds9/library/wcs.tcl
@@ -164,6 +164,7 @@ proc WCSDialog {} {
     set dwcs(ext) 1
 
     Toplevel $w $mb 6 [msgcat::mc {WCS Parameters}] WCSDestroyDialog
+    wm geometry $w "760x680"
 
     $mb add cascade -label [msgcat::mc {File}] -menu $mb.file
     $mb add cascade -label [msgcat::mc {Edit}] -menu $mb.edit


### PR DESCRIPTION
This closes #345 

If connected to an external hub then Start and Information are disabled.

If the external hub disconnects (and sends the proper `disconnect` mtype then re-enable the Start and Information options.

This also fixes a problem where with certain Themes the SAMP Information window and the WCS Parameter windows would take up the full screen. 