### PR TITLE
Fix crash connecting to external SAMP hubs (e.g. astropy samp_hub)

### DIFF
--- a/ds9/library/sampclient.tcl
+++ b/ds9/library/sampclient.tcl
@@ -9,7 +9,7 @@ proc SAMPConnectInit {verbose output debug} {
 
     # connected?
     if {[info exists samp]} {
-	if {$samp(verbose)} {
+	if {[info exists samp(verbose)] && $samp(verbose)} {
 	    SAMPError "SAMP: already connected"
 	}
 	return 0

--- a/ds9/library/samphub.tcl
+++ b/ds9/library/samphub.tcl
@@ -517,12 +517,11 @@ proc SAMPHubSend {method url params resultVar {flag {}}} {
 	puts stderr "SAMPHubSend: $method $url $params $flag"
     }
 
-    # figure out xmlrpc-?
-    set rpc {xmlrpc}
+    # use whatever path the endpoint url specifies (if any); the SAMP
+    # standard profile does not mandate a fixed path such as "xmlrpc"
+    set rpc {}
     if {[ParseURL $url r]} {
-	if {$r(path) != {}} {
-	    set rpc [string range $r(path) 1 end]
-	}
+	set rpc [string range $r(path) 1 end]
     }
 
     if {[catch {set result [xmlrpcCall $url $rpc $method $params]}]} {

--- a/ds9/library/samphub.tcl
+++ b/ds9/library/samphub.tcl
@@ -33,8 +33,15 @@ proc SAMPHubStart {verbose} {
     set samp(debug) $debug(tcl,samp)
     if {[SAMPParseHub]} {
 	# ok, found one, is it alive?
+	# samp(url) is authority-only; re-attach the path SAMPParseHub
+	# split off into samp(method), or SAMPHubSend has nothing to derive
+	# the endpoint path from
+	set huburl $samp(url)
+	if {$samp(method) != {}} {
+	    append huburl "/$samp(method)"
+	}
 	set rr {}
-	if {[SAMPHubSend {samp.hub.ping} $samp(url) {} rr]} {
+	if {[SAMPHubSend {samp.hub.ping} $huburl {} rr]} {
 	    # yes, its alive
 	    if {$verbose} {
 		Error "SAMPHub: [msgcat::mc {found existing hub}]"

--- a/ds9/library/xmlrpc.tcl
+++ b/ds9/library/xmlrpc.tcl
@@ -309,6 +309,8 @@ proc xmlrpcBuildRequest {method mname params} {
 }
 
 proc xmlrpcParseHTTPCode {str} {
+    global xmlrpc
+
     set DIGIT "\[0-9\]";		# Digit
 
     set	RE "HTTP/";				# HTTP message


### PR DESCRIPTION
xmlrpcParseHTTPCode read $xmlrpc(debug) without a global declaration, unlike every other proc in xmlrpc.tcl. It's only reached when an XML-RPC response's HTTP status isn't exactly "200", which an externally-started hub can trigger, crashing with "can't read xmlrpc(debug): no such variable" during ds9's automatic hub-detection ping at startup.

Because that error occurs inside an async fileevent callback, the pending vwait never completes and SAMPHubStart never reaches its cleanup, leaving a half-populated global samp array (no "verbose" key) behind. Clicking SAMP -> Connect then hit that stale array and crashed reading samp(verbose). Guard the "already connected" check so a similar partial-state array fails gracefully instead of crashing.