### PR TITLE
Guard samp.hub.event.unregister against untracked client ids

### DIFF
--- a/ds9/library/sampclient.tcl
+++ b/ds9/library/sampclient.tcl
@@ -549,8 +549,13 @@ proc samp.hub.event.unregister {msgid args} {
 	    id {
 		set id [lsearch $samp(clients) $val]
 		set samp(clients) [lreplace $samp(clients) $id $id]
-		unset samp($val,subscriptions)
-		unset samp($val,name)
+		# a hub may report a client (eg ourself) we never tracked
+		if {[info exists samp($val,subscriptions)]} {
+		    unset samp($val,subscriptions)
+		}
+		if {[info exists samp($val,name)]} {
+		    unset samp($val,name)
+		}
 	    }
 	}
     }


### PR DESCRIPTION
ds9 only tracks per-client subscriptions/name for OTHER registered clients (samp.hub.getRegisteredClients excludes the caller itself, per the SAMP spec), so samp(clients) never includes ds9's own client id. A hub that broadcasts a samp.hub.event.unregister notification for an id ds9 never tracked -- e.g. its own id, as some hubs do while tearing down all registrations on shutdown -- hit an unconditional unset on a nonexistent array element and crashed with a Tcl internal error:

  can't unset "samp(cl1,subscriptions)": no such element in array

Reproduced directly: registered ds9 with a real hub, then invoked samp.hub.event.unregister for ds9's own (untracked) client id via the tcl XPA entry point, hitting the exact crash. Guard both unset calls with info exists, matching the defensive style already used elsewhere in this file.

This closes #356 