### PR TITLE
Fix xmlrpcReadHeader misidentifying header/body boundary

### DIFF
--- a/ds9/library/xmlrpc.tcl
+++ b/ds9/library/xmlrpc.tcl
@@ -186,21 +186,25 @@ proc xmlrpcReadHeader {sock} {
 	    return {}
 	}
 	append buffer $buff
+	# a bare "\n\n" can legitimately occur inside the body itself (eg
+	# the blank line our own pretty-printer emits for a params-less
+	# methodCall), so we can't just prefer it over "\r\n\r\n" -- use
+	# whichever separator actually occurs earliest in the buffer
 	set nindex [string first "\n\n" $buffer]
+	set bindex [string first "\r\n\r\n" $buffer]
+	if {$bindex > 0 && ($nindex <= 0 || $bindex < $nindex)} {
+	    break
+	}
 	if {$nindex > 0} {
 	    break
 	}
-	set bindex [string first "\r\n\r\n" $buffer]
-	if {$bindex > 0} {
-	    break
-	}
     }
-    if {$nindex > 0} {
-	set header [string range $buffer 0 [expr $nindex - 1]]
-	set body [string range $buffer [expr $nindex + 2] end]
-    } elseif {$bindex > 0} {
+    if {$bindex > 0 && ($nindex <= 0 || $bindex < $nindex)} {
 	set header [string range $buffer 0 [expr $bindex - 1]]
 	set body [string range $buffer [expr $bindex + 4] end]
+    } elseif {$nindex > 0} {
+	set header [string range $buffer 0 [expr $nindex - 1]]
+	set body [string range $buffer [expr $nindex + 2] end]
     }
     return [list $header $body]
 }


### PR DESCRIPTION
xmlrpcReadHeader always preferred a bare "\n\n" separator over "\r\n\r\n" when both were present in the buffered data, regardless of which one actually marked the true header/body boundary. Since xmlrpcBuildRequest/xmlrpcResponse now emit "\r\n\r\n" (see the earlier CRLF framing fix), a bare "\n\n" occurring later in the buffer -- pure coincidence, not a real header terminator -- would be picked instead whenever one happened to be present.

That coincidence is not rare: our own XML pretty-printer emits a blank line in the body of any params-less methodCall, eg samp.hub.ping -> "...<methodName>samp.hub.ping</methodName>\n\n  </methodCall>\n". Any peer whose framing agrees with the true "\r\n\r\n" separator but whose body happens to contain this blank line hits the bug.

External hubs (Topcat, astropy) are immune since they parse HTTP with their own standard, Content-Length-driven reader, not this one. It bites when ds9 has to read a params-less call through its own reader: concretely, enabling "start as SAMP hub" (pds9(samp,hub)) alongside "auto-connect" (pds9(samp)) makes ds9 both hub and a client of its own hub, and the very first thing that client does is samp.hub.ping its own hub -- ds9 reading its own params-less request -- producing:

  Unrecognized HTTP Header format:
  Unrecognized HTTP code:

Reproduced directly by dumping the raw bytes xmlrpcNBRead received: confirmed the buffer contains a valid "\r\n\r\n" boundary followed later by the incidental in-body "\n\n", and that reverting just the CRLF framing change (bare LF headers) made the same scenario work, isolating this as a regression from that change. Fixed by picking whichever separator actually occurs earliest in the buffer, rather than unconditionally preferring "\n\n".

Verified clean startup (no errors) with SAMP hub+client self-connect, and re-verified no regression against a real external hub (Topcat): ds9 connects, and a real SAMP client can still query it via ds9.get.